### PR TITLE
DT-1846 add nunjucks filters for court type list filter

### DIFF
--- a/server/routes/courtRegister/allCourtsPagedView.ts
+++ b/server/routes/courtRegister/allCourtsPagedView.ts
@@ -14,5 +14,5 @@ export default class AllCourtsPagedView {
 
 export type AllCourtsFilter = {
   courtTypeIds: string[]
-  active: string
+  active?: boolean
 }

--- a/server/routes/courtRegister/allCourtsPagedView.ts
+++ b/server/routes/courtRegister/allCourtsPagedView.ts
@@ -1,4 +1,4 @@
-import { CourtsPage, CourtType } from '../../@types/courtRegister'
+import { CourtsPage } from '../../@types/courtRegister'
 import type { CourtsPageView } from './courtMapper'
 import { courtsPageMapper } from './courtMapper'
 

--- a/server/routes/courtRegister/allCourtsPagedView.ts
+++ b/server/routes/courtRegister/allCourtsPagedView.ts
@@ -1,4 +1,4 @@
-import { CourtsPage } from '../../@types/courtRegister'
+import { CourtsPage, CourtType } from '../../@types/courtRegister'
 import type { CourtsPageView } from './courtMapper'
 import { courtsPageMapper } from './courtMapper'
 
@@ -10,4 +10,9 @@ export default class AllCourtsPagedView {
   get renderArgs(): CourtsPageView {
     return this.courtsPageView
   }
+}
+
+export type AllCourtsFilter = {
+  courtTypeIds: string[]
+  active: string
 }

--- a/server/utils/nunjucksSetup.test.ts
+++ b/server/utils/nunjucksSetup.test.ts
@@ -182,7 +182,7 @@ describe('toCourtTypeFilterCheckboxes', () => {
   const app = express()
   const njk = nunjucksSetup(app)
   it('should create checkboxes metadata', () => {
-    const result = njk.getFilter('toCourtTypeFilterCheckboxes')([], { courtTypes: [], active: null })
+    const result = njk.getFilter('toCourtTypeFilterCheckboxes')([], { courtTypeIds: [], active: null })
     expect(result.idPrefix).toEqual('courtType')
     expect(result.name).toEqual('courtType')
     expect(result.classes).toContain('govuk-checkboxes')
@@ -275,7 +275,7 @@ describe('toActiveFilterRadioButtons', () => {
   const app = express()
   const njk = nunjucksSetup(app)
   it('should create radio button metadata', () => {
-    const result = njk.getFilter('toActiveFilterRadioButtons')({ courtTypes: [], active: null })
+    const result = njk.getFilter('toActiveFilterRadioButtons')({ courtTypeIds: [], active: null })
     expect(result.idPrefix).toEqual('active')
     expect(result.name).toEqual('active')
     expect(result.classes).toContain('govuk-radios')
@@ -283,7 +283,7 @@ describe('toActiveFilterRadioButtons', () => {
     expect(result.fieldset.legend.classes).toContain('govuk-fieldset')
   })
   it('should map null to all courts', () => {
-    const result = njk.getFilter('toActiveFilterRadioButtons')({ courtTypes: [], active: null })
+    const result = njk.getFilter('toActiveFilterRadioButtons')({ courtTypeIds: [], active: null })
     expect(result.items).toEqual([
       {
         value: '',
@@ -303,7 +303,7 @@ describe('toActiveFilterRadioButtons', () => {
     ])
   })
   it('should map true to open courts', () => {
-    const result = njk.getFilter('toActiveFilterRadioButtons')({ courtTypes: [], active: true })
+    const result = njk.getFilter('toActiveFilterRadioButtons')({ courtTypeIds: [], active: true })
     expect(result.items).toEqual([
       {
         value: '',
@@ -323,7 +323,7 @@ describe('toActiveFilterRadioButtons', () => {
     ])
   })
   it('should map false to closed courts', () => {
-    const result = njk.getFilter('toActiveFilterRadioButtons')({ courtTypes: [], active: false })
+    const result = njk.getFilter('toActiveFilterRadioButtons')({ courtTypeIds: [], active: false })
     expect(result.items).toEqual([
       {
         value: '',
@@ -341,5 +341,98 @@ describe('toActiveFilterRadioButtons', () => {
         checked: true,
       },
     ])
+  })
+})
+describe('toCourtListFilter', () => {
+  const app = express()
+  const njk = nunjucksSetup(app)
+  it('should show filter headings', () => {
+    const result = njk.getFilter('toCourtListFilter')([], { courtTypeIds: [], active: null })
+    expect(result.heading.text).toBeTruthy()
+    expect(result.selectedFilters.heading.text).toBeTruthy()
+    expect(result.selectedFilters.clearLink.text).toBeTruthy()
+  })
+  it('should show selected court types and active all', () => {
+    const result = njk.getFilter('toCourtListFilter')(
+      [
+        { courtType: 'CRN', courtName: 'Crown' },
+        { courtType: 'COU', courtName: 'County' },
+        { courtType: 'MAG', courtName: 'Magistrates' },
+      ],
+      { courtTypeIds: ['CRN', 'MAG'], active: null }
+    )
+    expect(result.categories).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          heading: {
+            text: 'Court Types',
+          },
+          items: [
+            {
+              href: '#',
+              text: 'Crown',
+            },
+            {
+              href: '#',
+              text: 'Magistrates',
+            },
+          ],
+        }),
+      ])
+    )
+  })
+  it('should show active All', () => {
+    const result = njk.getFilter('toCourtListFilter')([], { courtTypeIds: [], active: null })
+    expect(result.categories).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          heading: {
+            text: 'Active?',
+          },
+          items: [
+            {
+              href: '#',
+              text: 'All',
+            },
+          ],
+        }),
+      ])
+    )
+  })
+  it('should show active Open', () => {
+    const result = njk.getFilter('toCourtListFilter')([], { courtTypeIds: [], active: true })
+    expect(result.categories).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          heading: {
+            text: 'Active?',
+          },
+          items: [
+            {
+              href: '#',
+              text: 'Open',
+            },
+          ],
+        }),
+      ])
+    )
+  })
+  it('should show active Closed', () => {
+    const result = njk.getFilter('toCourtListFilter')([], { courtTypeIds: [], active: false })
+    expect(result.categories).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          heading: {
+            text: 'Active?',
+          },
+          items: [
+            {
+              href: '#',
+              text: 'Closed',
+            },
+          ],
+        }),
+      ])
+    )
   })
 })

--- a/server/utils/nunjucksSetup.test.ts
+++ b/server/utils/nunjucksSetup.test.ts
@@ -177,3 +177,101 @@ describe('toMojPagination', () => {
     })
   })
 })
+
+describe('toCourtTypeFilterCheckboxes', () => {
+  const app = express()
+  const njk = nunjucksSetup(app)
+  it('should create checkboxes metadata', () => {
+    const result = njk.getFilter('toCourtTypeFilterCheckboxes')([], { courtTypes: [], active: null })
+    expect(result.idPrefix).toEqual('courtType')
+    expect(result.name).toEqual('courtType')
+    expect(result.classes).toEqual('govuk-checkboxes--small')
+    expect(result.fieldset).toEqual({
+      legend: {
+        text: 'Court Types',
+        classes: 'govuk-fieldset__legend--m',
+      },
+    })
+  })
+  it('should map an empty filter to unchecked checkboxes', () => {
+    const result = njk.getFilter('toCourtTypeFilterCheckboxes')(
+      [
+        { courtType: 'CRN', courtName: 'Crown' },
+        { courtType: 'COU', courtName: 'County' },
+        { courtType: 'MAG', courtName: 'Magistrates' },
+      ],
+      { courtTypeIds: [], active: null }
+    )
+    expect(result.items).toEqual([
+      {
+        value: 'CRN',
+        text: 'Crown',
+        checked: false,
+      },
+      {
+        value: 'COU',
+        text: 'County',
+        checked: false,
+      },
+      {
+        value: 'MAG',
+        text: 'Magistrates',
+        checked: false,
+      },
+    ])
+  })
+  it('should map a single item to a single checked checkbox', () => {
+    const result = njk.getFilter('toCourtTypeFilterCheckboxes')(
+      [
+        { courtType: 'CRN', courtName: 'Crown' },
+        { courtType: 'COU', courtName: 'County' },
+        { courtType: 'MAG', courtName: 'Magistrates' },
+      ],
+      { courtTypeIds: ['CRN'], active: null }
+    )
+    expect(result.items).toEqual([
+      {
+        value: 'CRN',
+        text: 'Crown',
+        checked: true,
+      },
+      {
+        value: 'COU',
+        text: 'County',
+        checked: false,
+      },
+      {
+        value: 'MAG',
+        text: 'Magistrates',
+        checked: false,
+      },
+    ])
+  })
+  it('should map multiple items to multiple checked checkboxes', () => {
+    const result = njk.getFilter('toCourtTypeFilterCheckboxes')(
+      [
+        { courtType: 'CRN', courtName: 'Crown' },
+        { courtType: 'COU', courtName: 'County' },
+        { courtType: 'MAG', courtName: 'Magistrates' },
+      ],
+      { courtTypeIds: ['COU', 'MAG'], active: null }
+    )
+    expect(result.items).toEqual([
+      {
+        value: 'CRN',
+        text: 'Crown',
+        checked: false,
+      },
+      {
+        value: 'COU',
+        text: 'County',
+        checked: true,
+      },
+      {
+        value: 'MAG',
+        text: 'Magistrates',
+        checked: true,
+      },
+    ])
+  })
+})

--- a/server/utils/nunjucksSetup.test.ts
+++ b/server/utils/nunjucksSetup.test.ts
@@ -352,7 +352,7 @@ describe('toCourtListFilter', () => {
     expect(result.selectedFilters.heading.text).toBeTruthy()
     expect(result.selectedFilters.clearLink.text).toBeTruthy()
   })
-  it('should show selected court types and active all', () => {
+  it('should show selected court types', () => {
     const result = njk.getFilter('toCourtListFilter')(
       [
         { courtType: 'CRN', courtName: 'Crown' },

--- a/server/utils/nunjucksSetup.test.ts
+++ b/server/utils/nunjucksSetup.test.ts
@@ -185,13 +185,9 @@ describe('toCourtTypeFilterCheckboxes', () => {
     const result = njk.getFilter('toCourtTypeFilterCheckboxes')([], { courtTypes: [], active: null })
     expect(result.idPrefix).toEqual('courtType')
     expect(result.name).toEqual('courtType')
-    expect(result.classes).toEqual('govuk-checkboxes--small')
-    expect(result.fieldset).toEqual({
-      legend: {
-        text: 'Court Types',
-        classes: 'govuk-fieldset__legend--m',
-      },
-    })
+    expect(result.classes).toContain('govuk-checkboxes')
+    expect(result.fieldset.legend.text).toBeTruthy()
+    expect(result.fieldset.legend.classes).toContain('govuk-fieldset')
   })
   it('should map an empty filter to unchecked checkboxes', () => {
     const result = njk.getFilter('toCourtTypeFilterCheckboxes')(
@@ -270,6 +266,78 @@ describe('toCourtTypeFilterCheckboxes', () => {
       {
         value: 'MAG',
         text: 'Magistrates',
+        checked: true,
+      },
+    ])
+  })
+})
+describe('toActiveFilterRadioButtons', () => {
+  const app = express()
+  const njk = nunjucksSetup(app)
+  it('should create radio button metadata', () => {
+    const result = njk.getFilter('toActiveFilterRadioButtons')({ courtTypes: [], active: null })
+    expect(result.idPrefix).toEqual('active')
+    expect(result.name).toEqual('active')
+    expect(result.classes).toContain('govuk-radios')
+    expect(result.fieldset.legend.text).toBeTruthy()
+    expect(result.fieldset.legend.classes).toContain('govuk-fieldset')
+  })
+  it('should map null to all courts', () => {
+    const result = njk.getFilter('toActiveFilterRadioButtons')({ courtTypes: [], active: null })
+    expect(result.items).toEqual([
+      {
+        value: '',
+        text: 'All',
+        checked: true,
+      },
+      {
+        value: true,
+        text: 'Open',
+        checked: false,
+      },
+      {
+        value: false,
+        text: 'Closed',
+        checked: false,
+      },
+    ])
+  })
+  it('should map true to open courts', () => {
+    const result = njk.getFilter('toActiveFilterRadioButtons')({ courtTypes: [], active: true })
+    expect(result.items).toEqual([
+      {
+        value: '',
+        text: 'All',
+        checked: false,
+      },
+      {
+        value: true,
+        text: 'Open',
+        checked: true,
+      },
+      {
+        value: false,
+        text: 'Closed',
+        checked: false,
+      },
+    ])
+  })
+  it('should map false to closed courts', () => {
+    const result = njk.getFilter('toActiveFilterRadioButtons')({ courtTypes: [], active: false })
+    expect(result.items).toEqual([
+      {
+        value: '',
+        text: 'All',
+        checked: false,
+      },
+      {
+        value: true,
+        text: 'Open',
+        checked: false,
+      },
+      {
+        value: false,
+        text: 'Closed',
         checked: true,
       },
     ])

--- a/server/utils/nunjucksSetup.ts
+++ b/server/utils/nunjucksSetup.ts
@@ -138,5 +138,52 @@ export default function nunjucksSetup(app: express.Application): nunjucks.Enviro
     }
   })
 
+  njkEnv.addFilter('toCourtListFilter', (courtTypes: CourtType[], allCourtsFilter: AllCourtsFilter) => {
+    const courtTypeItems = allCourtsFilter.courtTypeIds.map(courtTypeId => {
+      return {
+        href: '#',
+        text: courtTypes.filter(courtType => courtType.courtType === courtTypeId)[0].courtName,
+      }
+    })
+    let activeItemText = 'All'
+    if (allCourtsFilter.active === true) {
+      activeItemText = 'Open'
+    } else if (allCourtsFilter.active === false) {
+      activeItemText = 'Closed'
+    }
+    return {
+      heading: {
+        text: 'Filter',
+      },
+      selectedFilters: {
+        heading: {
+          text: 'Selected filters',
+        },
+        clearLink: {
+          text: 'Clear filters',
+        },
+      },
+      categories: [
+        {
+          heading: {
+            text: 'Court Types',
+          },
+          items: courtTypeItems,
+        },
+        {
+          heading: {
+            text: 'Active?',
+          },
+          items: [
+            {
+              href: '#',
+              text: activeItemText,
+            },
+          ],
+        },
+      ],
+    }
+  })
+
   return njkEnv
 }

--- a/server/utils/nunjucksSetup.ts
+++ b/server/utils/nunjucksSetup.ts
@@ -104,5 +104,39 @@ export default function nunjucksSetup(app: express.Application): nunjucks.Enviro
     }
   })
 
+  njkEnv.addFilter('toActiveFilterRadioButtons', (allCourtsFilter: AllCourtsFilter) => {
+    return {
+      idPrefix: 'active',
+      name: 'active',
+      classes: 'govuk-radios--inline',
+      fieldset: {
+        legend: {
+          text: 'Active?',
+          classes: 'govuk-fieldset__legend--l',
+        },
+      },
+      hint: {
+        text: 'Show only open or closed courts',
+      },
+      items: [
+        {
+          value: '',
+          text: 'All',
+          checked: allCourtsFilter.active === null,
+        },
+        {
+          value: true,
+          text: 'Open',
+          checked: allCourtsFilter.active === true,
+        },
+        {
+          value: false,
+          text: 'Closed',
+          checked: allCourtsFilter.active === false,
+        },
+      ],
+    }
+  })
+
   return njkEnv
 }

--- a/server/utils/nunjucksSetup.ts
+++ b/server/utils/nunjucksSetup.ts
@@ -2,6 +2,8 @@ import nunjucks from 'nunjucks'
 import express from 'express'
 import path from 'path'
 import { PageMetaData } from './page'
+import { AllCourtsFilter } from '../routes/courtRegister/allCourtsPagedView'
+import { CourtType } from '../@types/courtRegister'
 
 type Error = {
   href: string
@@ -79,5 +81,28 @@ export default function nunjucksSetup(app: express.Application): nunjucks.Enviro
       checked: item === value,
     }))
   })
+
+  njkEnv.addFilter('toCourtTypeFilterCheckboxes', (courtTypes: CourtType[], allCourtsFilter: AllCourtsFilter) => {
+    const courtTypeItems = courtTypes.map((courtType: CourtType) => {
+      return {
+        value: courtType.courtType,
+        text: courtType.courtName,
+        checked: allCourtsFilter.courtTypeIds.includes(courtType.courtType),
+      }
+    })
+    return {
+      idPrefix: 'courtType',
+      name: 'courtType',
+      classes: 'govuk-checkboxes--small',
+      fieldset: {
+        legend: {
+          text: 'Court Types',
+          classes: 'govuk-fieldset__legend--m',
+        },
+      },
+      items: courtTypeItems,
+    }
+  })
+
   return njkEnv
 }


### PR DESCRIPTION
For now this just contains the nunjucks filters to generate content required by the GDS macros - not applied to the actual html yet to keep the PR size down.