### PR TITLE
DT-1769 Split cypress spec into 3 small test suites

### DIFF
--- a/integration_tests/integration/court-register-add.spec.ts
+++ b/integration_tests/integration/court-register-add.spec.ts
@@ -1,64 +1,20 @@
 import IndexPage from '../pages'
 import AllCourtsPage from '../pages/court-register/allCourts'
-import AllCourtsPagedPage from '../pages/court-register/allCourtsPaged'
-import CourtDetailsPage from '../pages/court-register/courtDetails'
 import AddCourtDetailsPage from '../pages/court-register/addNewCourtDetails'
 import AddCourtBuildingPage from '../pages/court-register/addNewCourtBuilding'
 import AddCourtContactDetailsPage from '../pages/court-register/addNewCourtContactDetails'
 import AddCourtSummaryPage from '../pages/court-register/addNewCourtSummary'
 import AddCourtFinishedPage from '../pages/court-register/addNewCourtFinished'
-import AmendCourtDetailsPage from '../pages/court-register/amendCourtDetails'
+import { sheffieldCrownCourt, sheffieldMagistratesCourt, sheffieldYouthCourt } from '../mockApis/courtRegister'
 
-context('Court register', () => {
+context('Court register - Add new court', () => {
   beforeEach(() => {
     cy.task('reset')
     cy.task('stubLogin')
     cy.task('stubAuthUser')
-    cy.task('stubAllCourts', [
-      {
-        courtId: 'SHFCC',
-        courtName: 'Sheffield Crown Court',
-        courtDescription: 'Sheffield Main Court - Yorkshire',
-        type: { courtType: 'CRN', courtName: 'Crown' },
-        active: true,
-        buildings: [],
-      },
-      {
-        courtId: 'SHFMC',
-        courtName: 'Sheffield Magistrates Court',
-        courtDescription: 'Sheffield Secondary Court - Yorkshire',
-        type: { courtType: 'MAG', courtName: 'Magistrates' },
-        active: false,
-        buildings: [],
-      },
-    ])
+    cy.task('stubAllCourts', [sheffieldCrownCourt, sheffieldMagistratesCourt])
     cy.task('stubPageOfCourts', {
-      content: [
-        {
-          courtId: 'SHFCC',
-          courtName: 'Sheffield Crown Court',
-          courtDescription: 'Sheffield Main Court - Yorkshire',
-          type: { courtType: 'CRN', courtName: 'Crown' },
-          active: true,
-          buildings: [],
-        },
-        {
-          courtId: 'SHFMC',
-          courtName: 'Sheffield Magistrates Court',
-          courtDescription: 'Sheffield Secondary Court - Yorkshire',
-          type: { courtType: 'MAG', courtName: 'Magistrates' },
-          active: true,
-          buildings: [],
-        },
-        {
-          courtId: 'SHFYC',
-          courtName: 'Sheffield Youth Court',
-          courtDescription: 'Sheffield Youth Court - Yorkshire',
-          type: { courtType: 'YOUTH', courtName: 'Youth' },
-          active: false,
-          buildings: [],
-        },
-      ],
+      content: [sheffieldCrownCourt, { ...sheffieldMagistratesCourt, active: true }, sheffieldYouthCourt],
       last: false,
       totalPages: 2,
       totalElements: 4,
@@ -68,140 +24,15 @@ context('Court register', () => {
       numberOfElements: 3,
       empty: false,
     })
-    cy.task('stubCourt', {
-      courtId: 'SHFCC',
-      courtName: 'Sheffield Crown Court',
-      courtDescription: 'Sheffield Main Court - Yorkshire',
-      type: { courtType: 'CRN', courtName: 'Crown' },
-      active: true,
-      buildings: [],
-    })
-    cy.task('stubCourt', {
-      courtId: 'SHFMC',
-      courtName: 'Sheffield Magistrates Court',
-      courtDescription: 'Sheffield Secondary Court - Yorkshire',
-      type: { courtType: 'MAG', courtName: 'Magistrates' },
-      active: false,
-      buildings: [],
-    })
-    cy.task('stubUpdateCourt')
     cy.task('stubCourtTypes')
+    cy.task('stubCourt', sheffieldCrownCourt)
+    cy.task('stubCourt', sheffieldMagistratesCourt)
     cy.task('stubAddCourt')
     cy.task('stubAddCourtBuilding')
     cy.task('stubAddCourtBuildingContact')
     cy.login()
   })
 
-  it('Can navigate to court registers', () => {
-    IndexPage.verifyOnPage().courtRegisterLink().should('contain.text', 'Court register').click()
-    AllCourtsPage.verifyOnPage()
-  })
-
-  it('Will display all courts', () => {
-    IndexPage.verifyOnPage().courtRegisterLink().click()
-    const courtRegisterPage = AllCourtsPage.verifyOnPage()
-
-    {
-      const { code, name, type, status } = courtRegisterPage.courts(0)
-      code().contains('SHFCC')
-      name().contains('Sheffield Crown Court')
-      type().contains('Crown')
-      status().contains('Active')
-    }
-    {
-      const { code, name, type, status } = courtRegisterPage.courts(1)
-      code().contains('SHFMC')
-      name().contains('Sheffield Magistrates Court')
-      type().contains('Magistrates')
-      status().contains('Closed')
-    }
-  })
-
-  it('Will display a page of courts', () => {
-    // IndexPage.verifyOnPage().courtRegisterLink().click()  -  TODO Will need this when plumbing in the paged court list and removing the all courts list
-    IndexPage.verifyOnPage()
-    cy.visit('/court-register/paged') // TODO and this will need removing
-    const courtRegisterPagedPage = AllCourtsPagedPage.verifyOnPage()
-
-    {
-      const { code, name, type, status } = courtRegisterPagedPage.courts(0)
-      code().contains('SHFCC')
-      name().contains('Sheffield Crown Court')
-      type().contains('Crown')
-      status().contains('Active')
-    }
-    {
-      const { code, name, type, status } = courtRegisterPagedPage.courts(1)
-      code().contains('SHFMC')
-      name().contains('Sheffield Magistrates Court')
-      type().contains('Magistrates')
-      status().contains('Active')
-    }
-    {
-      const { code, name, type, status } = courtRegisterPagedPage.courts(2)
-      code().contains('SHFYC')
-      name().contains('Sheffield Youth Court')
-      type().contains('Youth')
-      status().contains('Closed')
-    }
-  })
-  it('Will display pagination controls', () => {
-    // IndexPage.verifyOnPage().courtRegisterLink().click()  -  TODO Will need this when plumbing in the paged court list and removign the all courts list
-    IndexPage.verifyOnPage()
-    cy.visit('/court-register/paged') // TODO and this will need removing
-    const courtRegisterPagedPage = AllCourtsPagedPage.verifyOnPage()
-
-    const pageLinks = courtRegisterPagedPage.pageLinks()
-    pageLinks.then(items => {
-      // TODO There must be a better way than this?
-      expect(items[0].href).to.equal(undefined)
-      expect(items[0].text).to.equal('1')
-      expect(items[0].selected).to.equal(true)
-      expect(items[1].href).to.equal('/court-register/paged?page=2')
-      expect(items[1].text).to.equal('2')
-      expect(items[1].selected).to.equal(false)
-      expect(items[2].href).to.equal('/court-register/paged?page=2')
-      expect(items[2].text).to.contain('Next')
-      expect(items[2].selected).to.equal(false)
-    })
-
-    const pageResults = courtRegisterPagedPage.pageResults()
-    pageResults.contains('Showing 1 to 3 of 4 results')
-  })
-  it('Can deactivate open court', () => {
-    IndexPage.verifyOnPage().courtRegisterLink().click()
-    AllCourtsPage.verifyOnPage().viewCourtLink('SHFCC').should('contain.text', 'Sheffield Crown Court').click()
-    CourtDetailsPage.verifyOnPage('Sheffield Crown Court').markAsClosedButton().click()
-    CourtDetailsPage.verifyOnPage('Sheffield Crown Court').deactivatedConfirmationBlock().should('exist')
-  })
-  it('Can activate closed court', () => {
-    IndexPage.verifyOnPage().courtRegisterLink().click()
-    AllCourtsPage.verifyOnPage().viewCourtLink('SHFMC').should('contain.text', 'Sheffield Magistrates Court').click()
-    CourtDetailsPage.verifyOnPage('Sheffield Magistrates Court').markAsOpenButton().click()
-    CourtDetailsPage.verifyOnPage('Sheffield Magistrates Court').activatedConfirmationBlock().should('exist')
-  })
-  describe('amending a court', () => {
-    beforeEach(() => {
-      IndexPage.verifyOnPage().courtRegisterLink().click()
-      AllCourtsPage.verifyOnPage().viewCourtLink('SHFMC').should('contain.text', 'Sheffield Magistrates Court').click()
-    })
-    it('should show summary of court with link to amend', () => {
-      const courtDetailsPage = CourtDetailsPage.verifyOnPage('Sheffield Magistrates Court')
-      courtDetailsPage.courtDetailsSection().should('contain.text', 'Sheffield Magistrates Court')
-      courtDetailsPage.courtDetailsSection().should('contain.text', 'Sheffield Secondary Court - Yorkshire')
-      courtDetailsPage.amendCourtDetailsLink().should('contain.text', 'Change')
-    })
-    it('can navigate to amend court details page', () => {
-      const courtDetailsPage = CourtDetailsPage.verifyOnPage('Sheffield Magistrates Court')
-      courtDetailsPage.amendCourtDetailsLink().click()
-      const amendCourtDetailsPage = AmendCourtDetailsPage.verifyOnPage('SHFMC')
-
-      amendCourtDetailsPage.name().should('have.value', 'Sheffield Magistrates Court')
-      amendCourtDetailsPage.description().should('have.value', 'Sheffield Secondary Court - Yorkshire')
-      amendCourtDetailsPage.type().should('have.value', 'MAG')
-      amendCourtDetailsPage.saveButton()
-    })
-  })
   describe('adding a new court', () => {
     const fillCourtDetailsPage = (id = 'SHXCC') => {
       const courtDetails = AddCourtDetailsPage.verifyOnPage()

--- a/integration_tests/integration/court-register-amend.spec.ts
+++ b/integration_tests/integration/court-register-amend.spec.ts
@@ -1,0 +1,67 @@
+import IndexPage from '../pages'
+import AllCourtsPage from '../pages/court-register/allCourts'
+import CourtDetailsPage from '../pages/court-register/courtDetails'
+import AmendCourtDetailsPage from '../pages/court-register/amendCourtDetails'
+import { sheffieldCrownCourt, sheffieldMagistratesCourt, sheffieldYouthCourt } from '../mockApis/courtRegister'
+
+context('Court register - amend existing court', () => {
+  beforeEach(() => {
+    cy.task('reset')
+    cy.task('stubLogin')
+    cy.task('stubAuthUser')
+    cy.task('stubAllCourts', [sheffieldCrownCourt, sheffieldMagistratesCourt])
+    cy.task('stubPageOfCourts', {
+      content: [sheffieldCrownCourt, { ...sheffieldMagistratesCourt, active: true }, sheffieldYouthCourt],
+      last: false,
+      totalPages: 2,
+      totalElements: 4,
+      number: 0,
+      size: 3,
+      first: true,
+      numberOfElements: 3,
+      empty: false,
+    })
+    cy.task('stubCourt', sheffieldCrownCourt)
+    cy.task('stubCourt', sheffieldMagistratesCourt)
+    cy.task('stubUpdateCourt')
+    cy.task('stubCourtTypes')
+    cy.login()
+  })
+
+  describe('amending a open court', () => {
+    beforeEach(() => {
+      IndexPage.verifyOnPage().courtRegisterLink().click()
+      AllCourtsPage.verifyOnPage().viewCourtLink('SHFCC').should('contain.text', 'Sheffield Crown Court').click()
+    })
+    it('Can deactivate open court', () => {
+      CourtDetailsPage.verifyOnPage('Sheffield Crown Court').markAsClosedButton().click()
+      CourtDetailsPage.verifyOnPage('Sheffield Crown Court').deactivatedConfirmationBlock().should('exist')
+    })
+  })
+  describe('amending a court', () => {
+    beforeEach(() => {
+      IndexPage.verifyOnPage().courtRegisterLink().click()
+      AllCourtsPage.verifyOnPage().viewCourtLink('SHFMC').should('contain.text', 'Sheffield Magistrates Court').click()
+    })
+    it('Can activate closed court', () => {
+      CourtDetailsPage.verifyOnPage('Sheffield Magistrates Court').markAsOpenButton().click()
+      CourtDetailsPage.verifyOnPage('Sheffield Magistrates Court').activatedConfirmationBlock().should('exist')
+    })
+    it('should show summary of court with link to amend', () => {
+      const courtDetailsPage = CourtDetailsPage.verifyOnPage('Sheffield Magistrates Court')
+      courtDetailsPage.courtDetailsSection().should('contain.text', 'Sheffield Magistrates Court')
+      courtDetailsPage.courtDetailsSection().should('contain.text', 'Sheffield Secondary Court - Yorkshire')
+      courtDetailsPage.amendCourtDetailsLink().should('contain.text', 'Change')
+    })
+    it('can navigate to amend court details page', () => {
+      const courtDetailsPage = CourtDetailsPage.verifyOnPage('Sheffield Magistrates Court')
+      courtDetailsPage.amendCourtDetailsLink().click()
+      const amendCourtDetailsPage = AmendCourtDetailsPage.verifyOnPage('SHFMC')
+
+      amendCourtDetailsPage.name().should('have.value', 'Sheffield Magistrates Court')
+      amendCourtDetailsPage.description().should('have.value', 'Sheffield Secondary Court - Yorkshire')
+      amendCourtDetailsPage.type().should('have.value', 'MAG')
+      amendCourtDetailsPage.saveButton()
+    })
+  })
+})

--- a/integration_tests/integration/court-register-list.spec.ts
+++ b/integration_tests/integration/court-register-list.spec.ts
@@ -1,0 +1,104 @@
+import IndexPage from '../pages'
+import AllCourtsPage from '../pages/court-register/allCourts'
+import AllCourtsPagedPage from '../pages/court-register/allCourtsPaged'
+import { sheffieldCrownCourt, sheffieldMagistratesCourt, sheffieldYouthCourt } from '../mockApis/courtRegister'
+
+context('Court register - court list navigation', () => {
+  beforeEach(() => {
+    cy.task('reset')
+    cy.task('stubLogin')
+    cy.task('stubAuthUser')
+    cy.task('stubAllCourts', [sheffieldCrownCourt, sheffieldMagistratesCourt])
+    cy.task('stubPageOfCourts', {
+      content: [sheffieldCrownCourt, { ...sheffieldMagistratesCourt, active: true }, sheffieldYouthCourt],
+      last: false,
+      totalPages: 2,
+      totalElements: 4,
+      number: 0,
+      size: 3,
+      first: true,
+      numberOfElements: 3,
+      empty: false,
+    })
+    cy.task('stubCourt', sheffieldCrownCourt)
+    cy.task('stubCourt', sheffieldMagistratesCourt)
+    cy.login()
+  })
+
+  it('Can navigate to court registers', () => {
+    IndexPage.verifyOnPage().courtRegisterLink().should('contain.text', 'Court register').click()
+    AllCourtsPage.verifyOnPage()
+  })
+
+  it('Will display all courts', () => {
+    IndexPage.verifyOnPage().courtRegisterLink().click()
+    const courtRegisterPage = AllCourtsPage.verifyOnPage()
+
+    {
+      const { code, name, type, status } = courtRegisterPage.courts(0)
+      code().contains('SHFCC')
+      name().contains('Sheffield Crown Court')
+      type().contains('Crown')
+      status().contains('Active')
+    }
+    {
+      const { code, name, type, status } = courtRegisterPage.courts(1)
+      code().contains('SHFMC')
+      name().contains('Sheffield Magistrates Court')
+      type().contains('Magistrates')
+      status().contains('Closed')
+    }
+  })
+
+  it('Will display a page of courts', () => {
+    // IndexPage.verifyOnPage().courtRegisterLink().click()  -  TODO Will need this when plumbing in the paged court list and removing the all courts list
+    IndexPage.verifyOnPage()
+    cy.visit('/court-register/paged') // TODO and this will need removing
+    const courtRegisterPagedPage = AllCourtsPagedPage.verifyOnPage()
+
+    {
+      const { code, name, type, status } = courtRegisterPagedPage.courts(0)
+      code().contains('SHFCC')
+      name().contains('Sheffield Crown Court')
+      type().contains('Crown')
+      status().contains('Active')
+    }
+    {
+      const { code, name, type, status } = courtRegisterPagedPage.courts(1)
+      code().contains('SHFMC')
+      name().contains('Sheffield Magistrates Court')
+      type().contains('Magistrates')
+      status().contains('Active')
+    }
+    {
+      const { code, name, type, status } = courtRegisterPagedPage.courts(2)
+      code().contains('SHFYC')
+      name().contains('Sheffield Youth Court')
+      type().contains('Youth')
+      status().contains('Closed')
+    }
+  })
+  it('Will display pagination controls', () => {
+    // IndexPage.verifyOnPage().courtRegisterLink().click()  -  TODO Will need this when plumbing in the paged court list and removign the all courts list
+    IndexPage.verifyOnPage()
+    cy.visit('/court-register/paged') // TODO and this will need removing
+    const courtRegisterPagedPage = AllCourtsPagedPage.verifyOnPage()
+
+    const pageLinks = courtRegisterPagedPage.pageLinks()
+    pageLinks.then(items => {
+      // TODO There must be a better way than this?
+      expect(items[0].href).to.equal(undefined)
+      expect(items[0].text).to.equal('1')
+      expect(items[0].selected).to.equal(true)
+      expect(items[1].href).to.equal('/court-register/paged?page=2')
+      expect(items[1].text).to.equal('2')
+      expect(items[1].selected).to.equal(false)
+      expect(items[2].href).to.equal('/court-register/paged?page=2')
+      expect(items[2].text).to.contain('Next')
+      expect(items[2].selected).to.equal(false)
+    })
+
+    const pageResults = courtRegisterPagedPage.pageResults()
+    pageResults.contains('Showing 1 to 3 of 4 results')
+  })
+})

--- a/integration_tests/mockApis/courtRegister.ts
+++ b/integration_tests/mockApis/courtRegister.ts
@@ -1,5 +1,32 @@
 import { SuperAgentRequest } from 'superagent'
 import { stubFor } from './wiremock'
+import { Court } from '../../server/@types/courtRegister'
+
+export const sheffieldCrownCourt: Court = {
+  courtId: 'SHFCC',
+  courtName: 'Sheffield Crown Court',
+  courtDescription: 'Sheffield Main Court - Yorkshire',
+  type: { courtType: 'CRN', courtName: 'Crown' },
+  active: true,
+  buildings: [],
+}
+export const sheffieldMagistratesCourt: Court = {
+  courtId: 'SHFMC',
+  courtName: 'Sheffield Magistrates Court',
+  courtDescription: 'Sheffield Secondary Court - Yorkshire',
+  type: { courtType: 'MAG', courtName: 'Magistrates' },
+  active: false,
+  buildings: [],
+}
+
+export const sheffieldYouthCourt: Court = {
+  courtId: 'SHFYC',
+  courtName: 'Sheffield Youth Court',
+  courtDescription: 'Sheffield Youth Court - Yorkshire',
+  type: { courtType: 'YOUTH', courtName: 'Youth' },
+  active: false,
+  buildings: [],
+}
 
 const stubPing = (): SuperAgentRequest =>
   stubFor({


### PR DESCRIPTION
Hard to review, but did the follwing
1. Split court register spec into 3 separate specs
2. Moved instances of mock data to shared module