### PR TITLE
[MAP-908] Use Manage Users API instead of HMPPS Auth for deprecated endpoints

### DIFF
--- a/feature.env
+++ b/feature.env
@@ -2,6 +2,7 @@ PORT=3007
 HMPPS_AUTH_URL=http://localhost:9091/auth
 TOKEN_VERIFICATION_API_URL=http://localhost:9091/verification
 PRISON_REGISTER_API_URL=http://localhost:9091/prison-register
+MANAGE_USERS_API_URL=http://localhost:9091/manage-users-api
 NODE_ENV=development
 API_CLIENT_ID=clientid
 API_CLIENT_SECRET=clientsecret

--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -10,6 +10,7 @@ generic-service:
     HMPPS_AUTH_URL: https://sign-in-dev.hmpps.service.justice.gov.uk/auth
     TOKEN_VERIFICATION_API_URL: https://token-verification-api-dev.prison.service.justice.gov.uk
     PRISON_REGISTER_API_URL: https://prison-register-dev.hmpps.service.justice.gov.uk
+    MANAGE_USERS_API_URL: https://manage-users-api-dev.hmpps.service.justice.gov.uk
 
     INGRESS_URL: https://registers-dev.hmpps.service.justice.gov.uk
 

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -10,7 +10,7 @@ generic-service:
     HMPPS_AUTH_URL: https://sign-in-preprod.hmpps.service.justice.gov.uk/auth
     TOKEN_VERIFICATION_API_URL: https://token-verification-api-preprod.prison.service.justice.gov.uk
     PRISON_REGISTER_API_URL: https://prison-register-preprod.hmpps.service.justice.gov.uk
-
+    MANAGE_USERS_API_URL: https://manage-users-api-preprod.hmpps.service.justice.gov.uk
     INGRESS_URL: https://registers-preprod.hmpps.service.justice.gov.uk
 
 # CloudPlatform AlertManager receiver to route prometheus alerts to slack

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -9,7 +9,7 @@ generic-service:
     HMPPS_AUTH_URL: https://sign-in.hmpps.service.justice.gov.uk/auth
     TOKEN_VERIFICATION_API_URL: https://token-verification-api.prison.service.justice.gov.uk
     PRISON_REGISTER_API_URL: https://prison-register.hmpps.service.justice.gov.uk
-
+    MANAGE_USERS_API_URL: https://manage-users-api.hmpps.service.justice.gov.uk
     INGRESS_URL: https://registers.hmpps.service.justice.gov.uk
 
 # CloudPlatform AlertManager receiver to route prometheus alerts to slack

--- a/integration_tests/integration/login.cy.ts
+++ b/integration_tests/integration/login.cy.ts
@@ -6,7 +6,7 @@ context('SignIn', () => {
   beforeEach(() => {
     cy.task('reset')
     cy.task('stubSignIn')
-    cy.task('stubAuthUser')
+    cy.task('stubManageUser')
   })
 
   it('Unauthenticated user directed to auth', () => {

--- a/integration_tests/integration/prison-register-add-address.cy.ts
+++ b/integration_tests/integration/prison-register-add-address.cy.ts
@@ -8,7 +8,7 @@ context('Prison register - add address to existing prison', () => {
   beforeEach(() => {
     cy.task('reset')
     cy.task('stubSignIn')
-    cy.task('stubAuthUser')
+    cy.task('stubManageUser')
     cy.task('stubGetPrisonsWithFilter', [albanyPrison, { ...belmarshPrison, active: false }, moorlandPrison])
     cy.task('stubGetPrison', moorlandPrison)
     cy.task('stubGetPrisonAddress')

--- a/integration_tests/integration/prison-register-add.cy.ts
+++ b/integration_tests/integration/prison-register-add.cy.ts
@@ -10,7 +10,7 @@ context('Prison register - Add new prison', () => {
   beforeEach(() => {
     cy.task('reset')
     cy.task('stubSignIn')
-    cy.task('stubAuthUser')
+    cy.task('stubManageUser')
     cy.task('stubGetPrisonsWithFilter', [albanyPrison, { ...belmarshPrison }, moorlandPrison])
     cy.task('stubGetPrison', albanyPrison)
     cy.task('stubGetPrison', moorlandPrison)

--- a/integration_tests/integration/prison-register-amend-address.cy.ts
+++ b/integration_tests/integration/prison-register-amend-address.cy.ts
@@ -8,7 +8,7 @@ context('Prison register - amend existing prison address', () => {
   beforeEach(() => {
     cy.task('reset')
     cy.task('stubSignIn')
-    cy.task('stubAuthUser')
+    cy.task('stubManageUser')
     cy.task('stubGetPrisonsWithFilter', [albanyPrison, { ...belmarshPrison, active: false }, moorlandPrison])
     cy.task('stubGetPrison', moorlandPrison)
     cy.task('stubGetPrisonAddress')

--- a/integration_tests/integration/prison-register-amend.cy.ts
+++ b/integration_tests/integration/prison-register-amend.cy.ts
@@ -8,7 +8,7 @@ context('Prison register - amend existing prison', () => {
   beforeEach(() => {
     cy.task('reset')
     cy.task('stubSignIn')
-    cy.task('stubAuthUser')
+    cy.task('stubManageUser')
     cy.task('stubGetPrisonsWithFilter', [albanyPrison, { ...belmarshPrison }, moorlandPrison])
     cy.task('stubGetPrison', moorlandPrison)
     cy.task('stubGetPrison', belmarshPrison)

--- a/integration_tests/integration/prison-register-delete-address.cy.ts
+++ b/integration_tests/integration/prison-register-delete-address.cy.ts
@@ -8,7 +8,7 @@ context('Prison register - delete prison address', () => {
   beforeEach(() => {
     cy.task('reset')
     cy.task('stubSignIn')
-    cy.task('stubAuthUser')
+    cy.task('stubManageUser')
     cy.task('stubGetPrisonsWithFilter', [albanyPrison, { ...belmarshPrison, active: false }, moorlandPrison])
     cy.task('stubGetPrison', moorlandPrison)
     cy.task('stubGetPrisonAddress')

--- a/integration_tests/integration/prison-register-details.cy.ts
+++ b/integration_tests/integration/prison-register-details.cy.ts
@@ -7,7 +7,7 @@ context('Prison register - prison details navigation', () => {
   beforeEach(() => {
     cy.task('reset')
     cy.task('stubSignIn')
-    cy.task('stubAuthUser')
+    cy.task('stubManageUser')
     cy.task('stubGetPrisonsWithFilter', [albanyPrison, moorlandPrison])
     cy.task('stubGetPrison', moorlandPrison)
     cy.task('stubGetPrison', albanyPrison)

--- a/integration_tests/integration/prison-register-list.cy.ts
+++ b/integration_tests/integration/prison-register-list.cy.ts
@@ -6,7 +6,7 @@ context('Prison register - prison list navigation', () => {
   beforeEach(() => {
     cy.task('reset')
     cy.task('stubSignIn')
-    cy.task('stubAuthUser')
+    cy.task('stubManageUser')
     cy.task('stubGetPrisonsWithFilter', [moorlandPrison])
     cy.signIn()
   })

--- a/integration_tests/mockApis/auth.ts
+++ b/integration_tests/mockApis/auth.ts
@@ -100,45 +100,9 @@ const token = (roles: string[]) =>
     },
   })
 
-const stubUser = () =>
-  stubFor({
-    request: {
-      method: 'GET',
-      urlPattern: '/auth/api/user/me',
-    },
-    response: {
-      status: 200,
-      headers: {
-        'Content-Type': 'application/json;charset=UTF-8',
-      },
-      jsonBody: {
-        staffId: 231232,
-        username: 'USER1',
-        active: true,
-        name: 'john smith',
-      },
-    },
-  })
-
-const stubUserRoles = () =>
-  stubFor({
-    request: {
-      method: 'GET',
-      urlPattern: '/auth/api/user/me/roles',
-    },
-    response: {
-      status: 200,
-      headers: {
-        'Content-Type': 'application/json;charset=UTF-8',
-      },
-      jsonBody: [{ roleId: 'SOME_USER_ROLE' }],
-    },
-  })
-
 export default {
   getSignInUrl,
   stubPing: (): Promise<Array<Response>> => Promise.all([ping(), tokenVerification.stubPing()]),
   stubSignIn: (roles = ['ROLE_HMPPS_REGISTERS_MAINTAINER']): Promise<Array<Response>> =>
     Promise.all([favicon(), redirect(), signOut(), token(roles), tokenVerification.stubVerifyToken()]),
-  stubUser: (): Promise<Array<Response>> => Promise.all([stubUser(), stubUserRoles()]),
 }

--- a/integration_tests/mockApis/manageUsersApi.ts
+++ b/integration_tests/mockApis/manageUsersApi.ts
@@ -1,0 +1,36 @@
+import { stubFor } from './wiremock'
+
+const stubUser = (name: string = 'john smith') =>
+  stubFor({
+    request: {
+      method: 'GET',
+      urlPattern: '/manage-users-api/users/me',
+    },
+    response: {
+      status: 200,
+      headers: {
+        'Content-Type': 'application/json;charset=UTF-8',
+      },
+      jsonBody: {
+        username: 'USER1',
+        active: true,
+        name,
+      },
+    },
+  })
+
+const ping = () =>
+  stubFor({
+    request: {
+      method: 'GET',
+      urlPattern: '/manage-users-api/health/ping',
+    },
+    response: {
+      status: 200,
+    },
+  })
+
+export default {
+  stubManageUser: stubUser,
+  stubManageUsersPing: ping,
+}

--- a/integration_tests/plugins/index.ts
+++ b/integration_tests/plugins/index.ts
@@ -3,6 +3,7 @@ import { resetStubs } from '../mockApis/wiremock'
 import auth from '../mockApis/auth'
 import tokenVerification from '../mockApis/tokenVerification'
 import prisonRegister from '../mockApis/prisonRegister'
+import manageUsersApi from '../mockApis/manageUsersApi'
 
 export default (on: (task: string, tasks: Record<string, unknown>) => void): void => {
   on('task', {
@@ -11,7 +12,7 @@ export default (on: (task: string, tasks: Record<string, unknown>) => void): voi
     getSignInUrl: auth.getSignInUrl,
     stubSignIn: auth.stubSignIn,
 
-    stubAuthUser: auth.stubUser,
+    stubManageUser: manageUsersApi.stubManageUser,
     stubAuthPing: auth.stubPing,
 
     stubTokenVerificationPing: tokenVerification.stubPing,

--- a/package-lock.json
+++ b/package-lock.json
@@ -90,7 +90,7 @@
         "sass": "^1.72.0",
         "supertest": "^6.3.4",
         "ts-jest": "^29.1.2",
-        "typescript": "^5.4.2"
+        "typescript": "^5.4.5"
       },
       "engines": {
         "node": "^20",
@@ -11010,9 +11010,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.4.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.2.tgz",
-      "integrity": "sha512-+2/g0Fds1ERlP6JsakQQDXjZdZMM+rqpamFZJEKh4kwTIn3iDkgKtby0CeNd5ATNZ4Ry1ax15TMx0W2V+miizQ==",
+      "version": "5.4.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.5.tgz",
+      "integrity": "sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -19579,9 +19579,9 @@
       }
     },
     "typescript": {
-      "version": "5.4.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.2.tgz",
-      "integrity": "sha512-+2/g0Fds1ERlP6JsakQQDXjZdZMM+rqpamFZJEKh4kwTIn3iDkgKtby0CeNd5ATNZ4Ry1ax15TMx0W2V+miizQ==",
+      "version": "5.4.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.5.tgz",
+      "integrity": "sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==",
       "dev": true
     },
     "uid-safe": {

--- a/package.json
+++ b/package.json
@@ -165,6 +165,6 @@
     "sass": "^1.72.0",
     "supertest": "^6.3.4",
     "ts-jest": "^29.1.2",
-    "typescript": "^5.4.2"
+    "typescript": "^5.4.5"
   }
 }

--- a/server/config.ts
+++ b/server/config.ts
@@ -76,6 +76,14 @@ export default {
       },
       agent: new AgentConfig(),
     },
+    manageUsersApi: {
+      url: get('MANAGE_USERS_API_URL', 'http://localhost:9091', requiredInProduction),
+      timeout: {
+        response: Number(get('MANAGE_USERS_API_TIMEOUT_RESPONSE', 10000)),
+        deadline: Number(get('MANAGE_USERS_API_TIMEOUT_DEADLINE', 10000)),
+      },
+      agent: new AgentConfig(),
+    },
   },
   domain: get('INGRESS_URL', 'http://localhost:3000', requiredInProduction) as string,
 }

--- a/server/data/hmppsAuthClient.test.ts
+++ b/server/data/hmppsAuthClient.test.ts
@@ -25,32 +25,6 @@ describe('hmppsAuthClient', () => {
     nock.cleanAll()
   })
 
-  describe('getUser', () => {
-    it('should return data from api', async () => {
-      const response = { data: 'data' }
-
-      fakeHmppsAuthApi
-        .get('/api/user/me')
-        .matchHeader('authorization', `Bearer ${token.access_token}`)
-        .reply(200, response)
-
-      const output = await hmppsAuthClient.getUser(token.access_token)
-      expect(output).toEqual(response)
-    })
-  })
-
-  describe('getUserRoles', () => {
-    it('should return data from api', async () => {
-      fakeHmppsAuthApi
-        .get('/api/user/me/roles')
-        .matchHeader('authorization', `Bearer ${token.access_token}`)
-        .reply(200, [{ roleCode: 'role1' }, { roleCode: 'role2' }])
-
-      const output = await hmppsAuthClient.getUserRoles(token.access_token)
-      expect(output).toEqual(['role1', 'role2'])
-    })
-  })
-
   describe('getSystemClientToken', () => {
     it('should instantiate the redis client', async () => {
       tokenStore.getToken.mockResolvedValue(token.access_token)

--- a/server/data/hmppsAuthClient.ts
+++ b/server/data/hmppsAuthClient.ts
@@ -5,7 +5,6 @@ import type TokenStore from './tokenStore'
 import logger from '../../logger'
 import config from '../config'
 import generateOauthClientToken from '../authentication/clientCredentials'
-import RestClient from './restClient'
 
 const timeoutSpec = config.apis.hmppsAuth.timeout
 const hmppsAuthUrl = config.apis.hmppsAuth.url
@@ -55,21 +54,6 @@ export interface UserRole {
 
 export default class HmppsAuthClient {
   constructor(private readonly tokenStore: TokenStore) {}
-
-  private static restClient(token: string): RestClient {
-    return new RestClient('HMPPS Auth Client', config.apis.hmppsAuth, token)
-  }
-
-  getUser(token: string): Promise<User> {
-    logger.info(`Getting user details: calling HMPPS Auth`)
-    return HmppsAuthClient.restClient(token).get({ path: '/api/user/me' }) as Promise<User>
-  }
-
-  getUserRoles(token: string): Promise<string[]> {
-    return HmppsAuthClient.restClient(token)
-      .get({ path: '/api/user/me/roles' })
-      .then(roles => (<UserRole[]>roles).map(role => role.roleCode)) as Promise<string[]>
-  }
 
   async getSystemClientToken(username?: string): Promise<string> {
     const key = username || '%ANONYMOUS%'

--- a/server/data/manageUsersApiClient.test.ts
+++ b/server/data/manageUsersApiClient.test.ts
@@ -1,0 +1,35 @@
+import nock from 'nock'
+
+import config from '../config'
+import ManageUsersApiClient from './manageUsersApiClient'
+
+const token = { access_token: 'token-1', expires_in: 300 }
+
+describe('manageUsersApiClient', () => {
+  let fakeManageUsersApiClient: nock.Scope
+  let manageUsersApiClient: ManageUsersApiClient
+
+  beforeEach(() => {
+    fakeManageUsersApiClient = nock(config.apis.manageUsersApi.url)
+    manageUsersApiClient = new ManageUsersApiClient()
+  })
+
+  afterEach(() => {
+    jest.resetAllMocks()
+    nock.cleanAll()
+  })
+
+  describe('getUser', () => {
+    it('should return data from api', async () => {
+      const response = { data: 'data' }
+
+      fakeManageUsersApiClient
+        .get('/users/me')
+        .matchHeader('authorization', `Bearer ${token.access_token}`)
+        .reply(200, response)
+
+      const output = await manageUsersApiClient.getUser(token.access_token)
+      expect(output).toEqual(response)
+    })
+  })
+})

--- a/server/data/manageUsersApiClient.ts
+++ b/server/data/manageUsersApiClient.ts
@@ -1,0 +1,30 @@
+import logger from '../../logger'
+import config from '../config'
+import RestClient from './restClient'
+
+export interface User {
+  username: string
+  name?: string
+  active?: boolean
+  authSource?: string
+  uuid?: string
+  userId?: string
+  activeCaseLoadId?: string // Will be removed from User. For now, use 'me/caseloads' endpoint in 'nomis-user-roles-api'
+}
+
+export interface UserRole {
+  roleCode: string
+}
+
+export default class ManageUsersApiClient {
+  constructor() {}
+
+  private static restClient(token: string): RestClient {
+    return new RestClient('Manage Users Api Client', config.apis.manageUsersApi, token)
+  }
+
+  getUser(token: string): Promise<User> {
+    logger.info('Getting user details: calling HMPPS Manage Users Api')
+    return ManageUsersApiClient.restClient(token).get<User>({ path: '/users/me' })
+  }
+}

--- a/server/index.ts
+++ b/server/index.ts
@@ -5,9 +5,12 @@ import TokenStore from './data/tokenStore'
 import UserService from './services/userService'
 import PrisonRegisterService from './services/prisonRegisterService'
 import { createMetricsApp } from './monitoring/metricsApp'
+import ManageUsersApiClient from './data/manageUsersApiClient'
 
 const hmppsAuthClient = new HmppsAuthClient(new TokenStore(createRedisClient({ legacyMode: false })))
-const userService = new UserService(hmppsAuthClient)
+const manageUsersApiClient = new ManageUsersApiClient()
+
+const userService = new UserService(manageUsersApiClient)
 const prisonRegisterService = new PrisonRegisterService(hmppsAuthClient)
 
 const app = createApp(userService, prisonRegisterService)

--- a/server/routes/testutils/mockUserService.ts
+++ b/server/routes/testutils/mockUserService.ts
@@ -1,17 +1,16 @@
 import UserService, { UserDetails } from '../../services/userService'
-import HmppsAuthClient from '../../data/hmppsAuthClient'
+import ManageUsersApiClient from '../../data/manageUsersApiClient'
 
-const user = {
+const user: UserDetails = {
   name: 'john smith',
-  firstName: 'john',
-  lastName: 'smith',
   username: 'user1',
   displayName: 'John Smith',
+  roles: [],
 }
 
 export default class MockUserService extends UserService {
   constructor() {
-    super({} as HmppsAuthClient)
+    super({} as ManageUsersApiClient)
   }
 
   async getUser(token: string): Promise<UserDetails> {

--- a/server/services/userService.test.ts
+++ b/server/services/userService.test.ts
@@ -1,29 +1,31 @@
 import UserService from './userService'
-import HmppsAuthClient, { User } from '../data/hmppsAuthClient'
-import TokenStore from '../data/tokenStore'
+import ManageUsersApiClient from '../data/manageUsersApiClient'
 
 jest.mock('../data/hmppsAuthClient')
 
-const token = 'some token'
+const token =
+  'eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJoZWxsbyI6IndvcmxkIiwiaWF0IjoxNzEyODMzNTgxfQ.msHZ1pMy8FoZkFyODFViloAD4jVcxxHrTRvCVmRd1uc'
 
 describe('User service', () => {
-  let hmppsAuthClient: jest.Mocked<HmppsAuthClient>
+  let manageUsersApiClient: jest.Mocked<ManageUsersApiClient>
   let userService: UserService
 
   describe('getUser', () => {
     beforeEach(() => {
-      hmppsAuthClient = new HmppsAuthClient({} as TokenStore) as jest.Mocked<HmppsAuthClient>
-      userService = new UserService(hmppsAuthClient)
+      manageUsersApiClient = new ManageUsersApiClient() as jest.Mocked<ManageUsersApiClient>
+      userService = new UserService(manageUsersApiClient)
     })
+
     it('Retrieves and formats user name', async () => {
-      hmppsAuthClient.getUser.mockResolvedValue({ name: 'john smith' } as User)
+      manageUsersApiClient.getUser = jest.fn().mockResolvedValue({ name: 'john smith', username: 'JSMITH' })
 
       const result = await userService.getUser(token)
 
       expect(result.displayName).toEqual('John Smith')
     })
+
     it('Propagates error', async () => {
-      hmppsAuthClient.getUser.mockRejectedValue(new Error('some error'))
+      manageUsersApiClient.getUser = jest.fn().mockRejectedValue(new Error('some error'))
 
       await expect(userService.getUser(token)).rejects.toEqual(new Error('some error'))
     })

--- a/server/services/userService.ts
+++ b/server/services/userService.ts
@@ -1,16 +1,23 @@
+import { jwtDecode } from 'jwt-decode'
 import convertToTitleCase from '../utils/utils'
-import type HmppsAuthClient from '../data/hmppsAuthClient'
+import type { User } from '../data/manageUsersApiClient'
+import ManageUsersApiClient from '../data/manageUsersApiClient'
 
-export interface UserDetails {
-  name: string
+export interface UserDetails extends User {
   displayName: string
+  roles: string[]
 }
 
 export default class UserService {
-  constructor(private readonly hmppsAuthClient: HmppsAuthClient) {}
+  constructor(private readonly manageUsersApiClient: ManageUsersApiClient) {}
 
   async getUser(token: string): Promise<UserDetails> {
-    const user = await this.hmppsAuthClient.getUser(token)
-    return { ...user, displayName: convertToTitleCase(user.name as string) }
+    const user = await this.manageUsersApiClient.getUser(token)
+    return { ...user, roles: this.getUserRoles(token), displayName: convertToTitleCase(user.name) }
+  }
+
+  getUserRoles(token: string): string[] {
+    const { authorities: roles = [] } = jwtDecode(token) as { authorities?: string[] }
+    return roles.map(role => role.substring(role.indexOf('_') + 1))
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -24,7 +24,8 @@
     "cypress",
     "**/*.spec.ts",
     "./cypress.config.ts",
-    "**/*.test.ts"
+    "**/*.test.ts",
+    "server/routes/testutils/*"
   ],
   "include": ["**/*.js", "**/*.ts"]
 }


### PR DESCRIPTION
This service slipped though the net and is still hitting HMPPS Auth for user details. It should be using Manage Users API.

[MAP-908]

[MAP-908]: https://dsdmoj.atlassian.net/browse/MAP-908?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ