### PR TITLE
MAP-2041 user can add welsh address for prisons in Wales only

### DIFF
--- a/integration_tests/integration/prison-register-add-welsh-address.cy.ts
+++ b/integration_tests/integration/prison-register-add-welsh-address.cy.ts
@@ -1,0 +1,72 @@
+import IndexPage from '../pages'
+import { cardiffPrison } from '../mockApis/prisonRegister'
+import AllPrisons from '../pages/prison-register/allPrisons'
+import PrisonDetailsPage from '../pages/prison-register/prisonDetails'
+import AddWelshPrisonAddressPage from '../pages/prison-register/addWelshPrisonAddress'
+
+context('Prison register - add address to existing prison', () => {
+  beforeEach(() => {
+    cy.task('reset')
+    cy.task('stubSignIn')
+    cy.task('stubManageUser')
+    cy.task('stubGetPrisonsWithFilter', [cardiffPrison])
+    cy.task('stubGetPrison', cardiffPrison)
+    cy.task('stubGetWelshPrisonAddress', { prisonId: 'CFI', addressId: '16' })
+    cy.signIn()
+  })
+
+  describe('adding a Welsh prison address', () => {
+    beforeEach(() => {
+      IndexPage.verifyOnPage().prisonRegisterLink().click()
+      AllPrisons.verifyOnPage().viewPrisonLink('CFI').should('contain.text', cardiffPrison.prisonName).click()
+    })
+
+    it('should show summary of prison with links', () => {
+      const prisonDetailsPage = PrisonDetailsPage.verifyOnPage(cardiffPrison.prisonName)
+      prisonDetailsPage.prisonDetailsSection().should('contain.text', cardiffPrison.prisonName)
+      prisonDetailsPage.addPrisonAddressLink('CFI').should('contain.text', 'Add another address')
+      prisonDetailsPage.addWelshAddressLink('16').should('contain.text', 'Add Welsh address')
+    })
+
+    it('can navigate to add prison address page', () => {
+      const prisonDetailsPage = PrisonDetailsPage.verifyOnPage(cardiffPrison.prisonName)
+      prisonDetailsPage.addWelshAddressLink('16').click()
+      const addPrisonAddressPage = AddWelshPrisonAddressPage.verifyOnPage('CFI')
+      addPrisonAddressPage.saveButton()
+    })
+
+    it('will validate add prison address page', () => {
+      const prisonDetailsPage = PrisonDetailsPage.verifyOnPage(cardiffPrison.prisonName)
+      prisonDetailsPage.addWelshAddressLink('16').click()
+      const addWelshPrisonAddressPage = AddWelshPrisonAddressPage.verifyOnPage('CFI')
+      addWelshPrisonAddressPage.townInWelsh().clear().type('  ')
+      addWelshPrisonAddressPage.saveButton().click()
+
+      const prisonDetailsWithErrors = AddWelshPrisonAddressPage.verifyOnPage('CFI')
+      prisonDetailsWithErrors.errorSummary().contains('Enter the town or city')
+    })
+
+    it('will return to prison details page confirming update', () => {
+      const prisonDetailsPage = PrisonDetailsPage.verifyOnPage(cardiffPrison.prisonName)
+      prisonDetailsPage.addWelshAddressLink('16').click()
+      const addWelshPrisonAddressPage = AddWelshPrisonAddressPage.verifyOnPage('CFI')
+      addWelshPrisonAddressPage.addressLine1InWelsh().type('Heol Knox')
+      addWelshPrisonAddressPage.addressLine2InWelsh().type('Hollybush')
+      addWelshPrisonAddressPage.townInWelsh().type('Caerdydd')
+      addWelshPrisonAddressPage.countyInWelsh().type('Glamorgan')
+      addWelshPrisonAddressPage.saveButton().click()
+
+      PrisonDetailsPage.verifyOnPage(cardiffPrison.prisonName).prisonUpdatedConfirmationBlock().should('exist')
+    })
+
+    it('will accept new address with minimal data', () => {
+      const prisonDetailsPage = PrisonDetailsPage.verifyOnPage(cardiffPrison.prisonName)
+      prisonDetailsPage.addWelshAddressLink('16').click()
+      const addWelshPrisonAddressPage = AddWelshPrisonAddressPage.verifyOnPage('CFI')
+      addWelshPrisonAddressPage.townInWelsh().type('Caerdydd')
+      addWelshPrisonAddressPage.saveButton().click()
+
+      PrisonDetailsPage.verifyOnPage(cardiffPrison.prisonName).prisonUpdatedConfirmationBlock().should('exist')
+    })
+  })
+})

--- a/integration_tests/integration/prison-register-details.cy.ts
+++ b/integration_tests/integration/prison-register-details.cy.ts
@@ -1,4 +1,4 @@
-import { albanyPrison, moorlandPrison } from '../mockApis/prisonRegister'
+import { albanyPrison, moorlandPrison, cardiffPrison } from '../mockApis/prisonRegister'
 import IndexPage from '../pages'
 import AllPrisons from '../pages/prison-register/allPrisons'
 import PrisonDetails from '../pages/prison-register/prisonDetails'
@@ -8,7 +8,7 @@ context('Prison register - prison details navigation', () => {
     cy.task('reset')
     cy.task('stubSignIn')
     cy.task('stubManageUser')
-    cy.task('stubGetPrisonsWithFilter', [albanyPrison, moorlandPrison])
+    cy.task('stubGetPrisonsWithFilter', [albanyPrison, moorlandPrison, cardiffPrison])
     cy.task('stubGetPrison', moorlandPrison)
     cy.task('stubGetPrison', albanyPrison)
     cy.signIn()
@@ -34,7 +34,7 @@ context('Prison register - prison details navigation', () => {
     prisonDetailsPage.prisonDetailsSection().should('contain.text', 'His Majesty’s Youth Offender Institution')
   })
 
-  it('Will display prison address details', () => {
+  it('Will display prison address details without link to add welsh address', () => {
     IndexPage.verifyOnPage().prisonRegisterLink().click()
     AllPrisons.verifyOnPage()
       .viewPrisonLink(moorlandPrison.prisonId)
@@ -49,6 +49,19 @@ context('Prison register - prison details navigation', () => {
     prisonDetailsPage.addressDetailsSection('21').should('contain.text', moorlandPrison.addresses[0].county)
     prisonDetailsPage.addressDetailsSection('21').should('contain.text', moorlandPrison.addresses[0].postcode)
     prisonDetailsPage.addressDetailsSection('21').should('contain.text', moorlandPrison.addresses[0].country)
+    prisonDetailsPage.addWelshAddressLink('21').should('not.exist')
+  })
+
+  it('Will display prison address with link to add welsh address', () => {
+    cy.task('stubGetPrison', cardiffPrison)
+
+    IndexPage.verifyOnPage().prisonRegisterLink().click()
+    AllPrisons.verifyOnPage()
+      .viewPrisonLink(cardiffPrison.prisonId)
+      .should('contain.text', cardiffPrison.prisonName)
+      .click()
+    const prisonDetailsPage = PrisonDetails.verifyOnPage(cardiffPrison.prisonName)
+    prisonDetailsPage.addWelshAddressLink('16').should('exist')
   })
 
   it('Will not display prison types when none present', () => {

--- a/integration_tests/mockApis/prisonRegister.ts
+++ b/integration_tests/mockApis/prisonRegister.ts
@@ -60,6 +60,20 @@ const stubGetPrisonAddress = (): SuperAgentRequest =>
       jsonBody: data.prisonAddress({}),
     },
   })
+const stubGetWelshPrisonAddress = (address: { prisonId: string; addressId: string }): SuperAgentRequest =>
+  stubFor({
+    request: {
+      method: 'PUT',
+      urlPattern: `/prison-register/prison-maintenance/id/${address.prisonId}/welsh-address/${address.addressId}`,
+    },
+    response: {
+      status: 200,
+      headers: {
+        'Content-Type': 'application/json;charset=UTF-8',
+      },
+      jsonBody: data.welshPrisonAddress({}),
+    },
+  })
 
 const stubAddPrison = (): SuperAgentRequest =>
   stubFor({
@@ -143,6 +157,7 @@ export default {
   stubUpdatePrisonAddress,
   stubAddPrisonAddress,
   stubDeletePrisonAddress,
+  stubGetWelshPrisonAddress,
 }
 
 // Mock data
@@ -179,6 +194,29 @@ export const belmarshPrison: Prison = {
       county: 'Greater London',
       postcode: 'SE28 0EB',
       country: 'England',
+    },
+  ],
+  types: [{ code: 'HMP', description: 'His Majesty’s Prison' }],
+  operators: [{ name: 'PSP' }],
+}
+
+export const cardiffPrison: Prison = {
+  prisonId: 'CFI',
+  prisonName: 'HMP Cardiff',
+  active: false,
+  male: true,
+  female: false,
+  contracted: false,
+  lthse: false,
+  addresses: [
+    {
+      id: 16,
+      addressLine1: '2 Knox Road',
+      addressLine2: 'Merrywheather',
+      town: 'Cardiff',
+      county: 'Glamorgan',
+      postcode: 'CF24 0UG',
+      country: 'Wales',
     },
   ],
   types: [{ code: 'HMP', description: 'His Majesty’s Prison' }],

--- a/integration_tests/pages/prison-register/addWelshPrisonAddress.ts
+++ b/integration_tests/pages/prison-register/addWelshPrisonAddress.ts
@@ -1,0 +1,14 @@
+import type { Page } from '../page'
+import page from '../page'
+
+const prisonAddress = {
+  saveButton: () => cy.contains('Save'),
+  addressLine1InWelsh: () => cy.get('#addressline1inwelsh'),
+  addressLine2InWelsh: () => cy.get('#addressline2inwelsh'),
+  townInWelsh: () => cy.get('#towninwelsh'),
+  countyInWelsh: () => cy.get('#countyinwelsh'),
+  errorSummary: () => cy.get('.govuk-error-summary'),
+}
+const verifyOnPage = (prisonId: string): typeof prisonAddress & Page =>
+  page(`Add Welsh prison address for ${prisonId}`, prisonAddress)
+export default { verifyOnPage }

--- a/integration_tests/pages/prison-register/prisonDetails.ts
+++ b/integration_tests/pages/prison-register/prisonDetails.ts
@@ -12,6 +12,7 @@ const prisonDetails = {
   amendAddressDetailsLink: (addressId: string) => cy.get(`[data-qa=amend-address-details-link-${addressId}]`),
   addPrisonAddressLink: (prisonId: string) => cy.get(`[data-qa=add-prison-address-link-${prisonId}]`),
   deletePrisonAddressLink: (addressId: string) => cy.get(`[data-qa=delete-address-details-link-${addressId}]`),
+  addWelshAddressLink: (addressId: string) => cy.get(`[data-qa=add-welsh-address-link-${addressId}]`),
 }
 
 const verifyOnPage = (prisonName: string): typeof prisonDetails & Page => page(prisonName, prisonDetails)

--- a/integration_tests/plugins/index.ts
+++ b/integration_tests/plugins/index.ts
@@ -26,5 +26,6 @@ export default (on: (task: string, tasks: Record<string, unknown>) => void): voi
     stubUpdatePrisonAddress: prisonRegister.stubUpdatePrisonAddress,
     stubAddPrisonAddress: prisonRegister.stubAddPrisonAddress,
     stubDeletePrisonAddress: prisonRegister.stubDeletePrisonAddress,
+    stubGetWelshPrisonAddress: prisonRegister.stubGetWelshPrisonAddress,
   })
 }

--- a/server/@types/express/index.d.ts
+++ b/server/@types/express/index.d.ts
@@ -3,6 +3,7 @@ import type {
   AmendPrisonDetailsForm,
   AmendPrisonAddressForm,
   AddPrisonAddressForm,
+  AddWelshPrisonAddressForm,
 } from '../prisonRegisterForms'
 
 export default {}
@@ -16,6 +17,7 @@ declare module 'express-session' {
     amendPrisonDetailsForm: AmendPrisonDetailsForm
     amendPrisonAddressForm: AmendPrisonAddressForm
     addPrisonAddressForm: AddPrisonAddressForm
+    addWelshPrisonAddressForm: AddWelshPrisonAddressForm
     prisonListPageLink: string
   }
 }

--- a/server/@types/prisonRegister/index.d.ts
+++ b/server/@types/prisonRegister/index.d.ts
@@ -2,6 +2,7 @@ import { components } from '../prisonRegisterImport'
 
 export type Prison = components['schemas']['PrisonDto']
 export type PrisonAddress = components['schemas']['AddressDto']
+export type WelshPrisonAddress = components['schemas']['WelshAddressDto']
 export type PrisonType = components['schemas']['PrisonTypeDto']
 export type OperatorType = components['schemas']['PrisonOperatorDto']
 export type InsertPrison = components['schemas']['InsertPrisonDto']

--- a/server/@types/prisonRegisterForms/index.d.ts
+++ b/server/@types/prisonRegisterForms/index.d.ts
@@ -35,4 +35,13 @@ declare module 'prisonForms' {
     addresspostcode: string
     addresscountry: string
   }
+  export interface WelshPrisonAddressForm {
+    addressId?: string
+    prisonId: string
+    addressline1inwelsh?: string
+    addressline2inwelsh?: string
+    towninwelsh: string
+    countyinwelsh?: string
+    countryinwelsh?: string
+  }
 }

--- a/server/@types/prisonRegisterImport/index.d.ts
+++ b/server/@types/prisonRegisterImport/index.d.ts
@@ -163,22 +163,22 @@ export interface components {
     WelshAddressDto: {
       /**
        * @description Address line 1
-       * @example Bawtry Road
+       * @example Some Road
        */
       addressLine1InWelsh?: string
       /**
        * @description Address line 2
-       * @example Hatfield Woodhouse
+       * @example Some area
        */
       addressLine2InWelsh?: string
       /**
        * @description Village/Town/City
-       * @example Doncaster
+       * @example Cardiff
        */
       townInWelsh: string
       /**
        * @description County
-       * @example South Yorkshire
+       * @example Glamorgan
        */
       countyInWelsh?: string
       /**
@@ -226,7 +226,32 @@ export interface components {
        * @example England
        */
       country: string
-    } & WelshAddressDto
+      /**
+       * @description Address line 1
+       * @example Some Road
+       */
+      addressLine1InWelsh?: string
+      /**
+       * @description Address line 2
+       * @example Some area
+       */
+      addressLine2InWelsh?: string
+      /**
+       * @description Village/Town/City
+       * @example Cardiff
+       */
+      townInWelsh?: string
+      /**
+       * @description County
+       * @example Glamorgan
+       */
+      countyInWelsh?: string
+      /**
+       * @description Country
+       * @example Cymru
+       */
+      countryInWelsh?: string
+    }
 
     /** @description Prison Information */
     PrisonDto: {

--- a/server/@types/prisonRegisterImport/index.d.ts
+++ b/server/@types/prisonRegisterImport/index.d.ts
@@ -197,6 +197,35 @@ export interface components {
        * @example England
        */
       country: string
+    } & WelshAddressDto
+
+    /** @description Address Update Record */
+    WelshAddressDto: {
+      /**
+       * @description Address line 1
+       * @example Bawtry Road
+       */
+      addressLine1InWelsh?: string
+      /**
+       * @description Address line 2
+       * @example Hatfield Woodhouse
+       */
+      addressLine2InWelsh?: string
+      /**
+       * @description Village/Town/City
+       * @example Doncaster
+       */
+      townInWelsh: string
+      /**
+       * @description County
+       * @example South Yorkshire
+       */
+      countyInWelsh?: string
+      /**
+       * @description Country
+       * @example Cymru
+       */
+      countryInWelsh?: string
     }
     /** @description Prison Information */
     PrisonDto: {

--- a/server/@types/prisonRegisterImport/index.d.ts
+++ b/server/@types/prisonRegisterImport/index.d.ts
@@ -159,6 +159,35 @@ export interface components {
       developerMessage?: string
       moreInfo?: string
     }
+    /** @description Welsh Address Record */
+    WelshAddressDto: {
+      /**
+       * @description Address line 1
+       * @example Bawtry Road
+       */
+      addressLine1InWelsh?: string
+      /**
+       * @description Address line 2
+       * @example Hatfield Woodhouse
+       */
+      addressLine2InWelsh?: string
+      /**
+       * @description Village/Town/City
+       * @example Doncaster
+       */
+      townInWelsh: string
+      /**
+       * @description County
+       * @example South Yorkshire
+       */
+      countyInWelsh?: string
+      /**
+       * @description Country
+       * @example Cymru
+       */
+      countryInWelsh?: string
+    }
+
     /** @description List of address for this prison */
     AddressDto: {
       /**
@@ -199,34 +228,6 @@ export interface components {
       country: string
     } & WelshAddressDto
 
-    /** @description Address Update Record */
-    WelshAddressDto: {
-      /**
-       * @description Address line 1
-       * @example Bawtry Road
-       */
-      addressLine1InWelsh?: string
-      /**
-       * @description Address line 2
-       * @example Hatfield Woodhouse
-       */
-      addressLine2InWelsh?: string
-      /**
-       * @description Village/Town/City
-       * @example Doncaster
-       */
-      townInWelsh: string
-      /**
-       * @description County
-       * @example South Yorkshire
-       */
-      countyInWelsh?: string
-      /**
-       * @description Country
-       * @example Cymru
-       */
-      countryInWelsh?: string
-    }
     /** @description Prison Information */
     PrisonDto: {
       /**

--- a/server/routes/prisonRegister/addNewPrisonAddressValidator.test.ts
+++ b/server/routes/prisonRegister/addNewPrisonAddressValidator.test.ts
@@ -5,7 +5,7 @@ import validate from './addNewPrisonAddressValidator'
 describe('addNewPrisonAddressValidator', () => {
   const req = {
     flash: jest.fn() as (type: string, message: Array<Record<string, string>>) => number,
-  } as Request
+  } as unknown as Request
 
   const validForm: AddNewPrisonForm = {
     gender: [],

--- a/server/routes/prisonRegister/addWelshPrisonAddressView.test.ts
+++ b/server/routes/prisonRegister/addWelshPrisonAddressView.test.ts
@@ -1,0 +1,25 @@
+import type { WelshPrisonAddressForm } from 'prisonForms'
+import AddWelshPrisonAddressView from './addWelshPrisonAddressView'
+
+describe('AddWelshPrisonAddressView', () => {
+  const form: WelshPrisonAddressForm = {
+    prisonId: 'CFI',
+    addressId: '123',
+    addressline1inwelsh: 'Line 1',
+    addressline2inwelsh: 'Line 2',
+    towninwelsh: 'Caerdydd',
+    countyinwelsh: 'Glamorgan',
+  }
+
+  it('will pass through the form', () => {
+    const view = new AddWelshPrisonAddressView(form, [])
+    expect(view.renderArgs.form).toEqual({
+      addressId: '123',
+      prisonId: 'CFI',
+      addressline1inwelsh: 'Line 1',
+      addressline2inwelsh: 'Line 2',
+      countyinwelsh: 'Glamorgan',
+      towninwelsh: 'Caerdydd',
+    })
+  })
+})

--- a/server/routes/prisonRegister/addWelshPrisonAddressView.ts
+++ b/server/routes/prisonRegister/addWelshPrisonAddressView.ts
@@ -1,0 +1,18 @@
+import type { WelshPrisonAddressForm } from 'prisonForms'
+
+export default class AddWelshPrisonAddressView {
+  constructor(
+    private readonly form: WelshPrisonAddressForm,
+    private readonly errors?: Array<Record<string, string>>,
+  ) {}
+
+  get renderArgs(): {
+    form: WelshPrisonAddressForm
+    errors: Array<Record<string, string>>
+  } {
+    return {
+      form: this.form,
+      errors: this.errors || [],
+    }
+  }
+}

--- a/server/routes/prisonRegister/prisonDetailsView.test.ts
+++ b/server/routes/prisonRegister/prisonDetailsView.test.ts
@@ -44,4 +44,92 @@ describe('PrisonDetailsView', () => {
     const view = new PrisonDetailsView(data.prison({}), 'ACTIVATE-PRISON')
     expect(view.renderArgs.action).toEqual('ACTIVATE-PRISON')
   })
+
+  it('will return isWelsh to be  false', () => {
+    const view = new PrisonDetailsView(
+      data.prison({
+        addresses: [
+          {
+            id: 22,
+            addressLine1: 'Alternative Address',
+            addressLine2: 'Hatfield Woodhouse',
+            town: 'Doncaster',
+            postcode: 'DN7 6BX',
+            county: 'South Yorkshire',
+            country: 'England',
+          },
+          data.prisonAddress({}),
+        ],
+      }),
+      'NONE',
+    )
+
+    expect(view.renderArgs.isWelshPrison).toEqual(false)
+  })
+
+  it('Will send both English and Welsh prison addresses to view', () => {
+    const view = new PrisonDetailsView(
+      data.prison({
+        prisonId: 'CFI',
+        prisonName: 'Cardiff',
+        addresses: [
+          data.prisonAddress({
+            id: 22,
+            addressLine1: '2 Knox Road',
+            addressLine2: undefined,
+            town: 'Cardiff',
+            postcode: 'CF24 0UG',
+            county: 'Glamorgan',
+            country: 'Wales',
+            addressLine1InWelsh: 'Heol Knox',
+            addressLine2InWelsh: undefined,
+            townInWelsh: 'Caerdydd',
+            countyInWelsh: undefined,
+            countryInWelsh: 'Cymru',
+          }),
+        ],
+      }),
+      'NONE',
+    )
+    expect(view.renderArgs).toEqual({
+      action: 'NONE',
+      isWelshPrison: true,
+      prisonDetails: {
+        active: true,
+        addresses: [
+          {
+            country: 'Wales',
+            countryinwelsh: 'Cymru',
+            county: 'Glamorgan',
+            hasWelshAddress: true,
+            id: 22,
+            line1: '2 Knox Road',
+            line1inwelsh: 'Heol Knox',
+            line2: 'Hatfield Woodhouse',
+            line2inwelsh: undefined,
+            postcode: 'CF24 0UG',
+            town: 'Cardiff',
+            towninwelsh: 'Caerdydd',
+          },
+        ],
+        contracted: false,
+        female: true,
+        id: 'CFI',
+        lthse: false,
+        male: true,
+        name: 'Cardiff',
+        operators: [
+          {
+            name: 'PSP',
+          },
+        ],
+        types: [
+          {
+            code: 'HMP',
+            description: 'His Majesty’s Prison',
+          },
+        ],
+      },
+    })
+  })
 })

--- a/server/routes/prisonRegister/prisonDetailsView.test.ts
+++ b/server/routes/prisonRegister/prisonDetailsView.test.ts
@@ -72,6 +72,7 @@ describe('PrisonDetailsView', () => {
       data.prison({
         prisonId: 'CFI',
         prisonName: 'Cardiff',
+        prisonNameInWelsh: 'Carchar Caerdydd',
         addresses: [
           data.prisonAddress({
             id: 22,
@@ -95,6 +96,7 @@ describe('PrisonDetailsView', () => {
       action: 'NONE',
       isWelshPrison: true,
       prisonDetails: {
+        prisonNameInWelsh: 'Carchar Caerdydd',
         active: true,
         addresses: [
           {

--- a/server/routes/prisonRegister/prisonDetailsView.ts
+++ b/server/routes/prisonRegister/prisonDetailsView.ts
@@ -1,4 +1,4 @@
-import prisonMapper, { PrisonDetail } from './prisonMapper'
+import prisonMapper, { PrisonDetail, addWelshAddressMarker } from './prisonMapper'
 import { Prison } from '../../@types/prisonRegister'
 
 export type Action = 'NONE' | 'ACTIVATE-PRISON' | 'DEACTIVATE-PRISON' | 'UPDATED'
@@ -11,7 +11,15 @@ export default class PrisonDetailsView {
 
   readonly prisonDetails: PrisonDetail = prisonMapper(this.prison)
 
-  get renderArgs(): { prisonDetails: PrisonDetail; action: Action } {
-    return { prisonDetails: this.prisonDetails, action: this.action }
+  readonly isWelshPrison: boolean = this.prisonDetails.addresses[0]?.country === 'Wales'
+
+  readonly prisonDetailsWithWelshAddressMarker = addWelshAddressMarker(this.prisonDetails)
+
+  get renderArgs(): { prisonDetails: PrisonDetail; action: Action; isWelshPrison: boolean } {
+    return {
+      prisonDetails: this.prisonDetailsWithWelshAddressMarker,
+      action: this.action,
+      isWelshPrison: this.isWelshPrison,
+    }
   }
 }

--- a/server/routes/prisonRegister/prisonMapper.ts
+++ b/server/routes/prisonRegister/prisonMapper.ts
@@ -26,6 +26,17 @@ export type AddressDetail = {
   county?: string
   postcode: string
   country: string
+  line1inwelsh?: string
+  line2inwelsh?: string
+  towninwelsh?: string
+  countryinwelsh?: string
+}
+
+export type WelshAddressDetail = {
+  line1inwelsh?: string
+  line2inwelsh?: string
+  towninwelsh?: string
+  countryinwelsh?: string
 }
 
 export type TypeDetail = {
@@ -67,7 +78,18 @@ export function addressMapper(address: PrisonAddress): AddressDetail {
     county: address.county,
     postcode: address.postcode,
     country: address.country,
+    line1inwelsh: address.addressLine1InWelsh,
+    line2inwelsh: address.addressLine2InWelsh,
+    towninwelsh: address.townInWelsh,
+    countryinwelsh: address.countryInWelsh,
   }
+}
+
+export function addWelshAddressMarker(prisonDetails) {
+  const addresses = prisonDetails.addresses.map(address =>
+    address.towninwelsh ? { ...address, hasWelshAddress: true } : { ...address, hasWelshAddress: false },
+  )
+  return { ...prisonDetails, addresses }
 }
 
 export function typeMapper(type: PrisonType): TypeDetail {

--- a/server/routes/prisonRegister/prisonRegisterController.test.ts
+++ b/server/routes/prisonRegister/prisonRegisterController.test.ts
@@ -225,37 +225,6 @@ describe('Prison Register controller', () => {
         action: 'NONE',
       })
     })
-
-    it('will render prison details page including welsh prison name', async () => {
-      prisonRegisterService.getPrison.mockResolvedValue(
-        data.prison({ prisonNameInWelsh: 'Carchar Brynbuga', addresses: [data.prisonAddress({})] }),
-      )
-
-      await controller.viewPrison(req, res)
-
-      expect(res.render).toHaveBeenCalledWith('pages/prison-register/prisonDetails', {
-        prisonDetails: expect.objectContaining({
-          id: 'ALI',
-          name: 'Albany (HMP)',
-          prisonNameInWelsh: 'Carchar Brynbuga',
-          active: true,
-          female: true,
-          male: true,
-          addresses: [
-            {
-              id: 21,
-              line1: 'Bawtry Road',
-              line2: 'Hatfield Woodhouse',
-              town: 'Doncaster',
-              country: 'England',
-              county: 'South Yorkshire',
-              postcode: 'DN7 6BW',
-            },
-          ],
-        }),
-        action: 'NONE',
-      })
-    })
   })
 
   describe('togglePrisonActive', () => {

--- a/server/routes/prisonRegister/prisonRegisterController.test.ts
+++ b/server/routes/prisonRegister/prisonRegisterController.test.ts
@@ -156,12 +156,13 @@ describe('Prison Register controller', () => {
       await controller.viewPrison(req, res)
 
       expect(res.render).toHaveBeenCalledWith('pages/prison-register/prisonDetails', {
-        prisonDetails: expect.objectContaining({ id: 'ALI' }),
         action: 'NONE',
+        prisonDetails: expect.objectContaining({ id: 'ALI' }),
+        isWelshPrison: false,
       })
     })
 
-    it('will render prison details page with address', async () => {
+    it('will render prison details page with English address only', async () => {
       await controller.viewPrison(req, res)
 
       expect(res.render).toHaveBeenCalledWith('pages/prison-register/prisonDetails', {
@@ -180,9 +181,47 @@ describe('Prison Register controller', () => {
               country: 'England',
               county: 'South Yorkshire',
               postcode: 'DN7 6BW',
+              countryinwelsh: undefined,
+              hasWelshAddress: false,
+              line1inwelsh: undefined,
+              line2inwelsh: undefined,
+              towninwelsh: undefined,
             },
           ],
         }),
+        isWelshPrison: false,
+        action: 'NONE',
+      })
+    })
+
+    it('will render prison details page with both English and Welsh address', async () => {
+      prisonRegisterService.getPrison.mockResolvedValue(
+        data.prison({ addresses: [data.combinedEnglishAddWelshAddress({})] }),
+      )
+
+      await controller.viewPrison(req, res)
+
+      expect(res.render).toHaveBeenCalledWith('pages/prison-register/prisonDetails', {
+        prisonDetails: expect.objectContaining({
+          active: true,
+          addresses: [
+            {
+              country: 'Wales',
+              countryinwelsh: undefined,
+              county: 'Glamorgan',
+              hasWelshAddress: true,
+              id: 21,
+              line1: '2 Knox Road',
+              line1inwelsh: 'Heol Knox',
+              line2: null,
+              line2inwelsh: 'Hollybush',
+              postcode: 'CC24 0UG',
+              town: 'Cardiff',
+              towninwelsh: 'Caerdydd',
+            },
+          ],
+        }),
+        isWelshPrison: true,
         action: 'NONE',
       })
     })
@@ -657,6 +696,35 @@ describe('Prison Register controller', () => {
       })
     })
 
+    describe('addWelshPrisonAddressStart', () => {
+      beforeEach(() => {
+        req.query = { prisonId: 'CFI', addressId: '123' }
+        res.locals.user = {
+          username: 'tom',
+        }
+      })
+
+      it("will render 'Add Welsh prison address' page", async () => {
+        await controller.addWelshPrisonAddressStart(req, res)
+
+        expect(res.render).toHaveBeenCalledWith('pages/prison-register/addWelshPrisonAddress', {
+          form: expect.objectContaining({}),
+          errors: [],
+        })
+      })
+      it('will create form and pass through to page', async () => {
+        await controller.addWelshPrisonAddressStart(req, res)
+
+        expect(res.render).toHaveBeenCalledWith('pages/prison-register/addWelshPrisonAddress', {
+          form: {
+            prisonId: 'CFI',
+            addressId: '123',
+          },
+          errors: [],
+        })
+      })
+    })
+
     describe('deletePrisonAddressStart', () => {
       beforeEach(() => {
         req.query.prisonId = 'MDI'
@@ -753,6 +821,42 @@ describe('Prison Register controller', () => {
       })
     })
 
+    describe('addWelshPrisonAddress', () => {
+      beforeEach(() => {
+        req.session.addWelshPrisonAddressForm = {
+          addressline1inwelsh: 'line 1',
+          addressline2inwelsh: 'line 2',
+          towninwelsh: 'Carchar Caerdydd',
+          countyinwelsh: 'Galmorgan',
+        }
+
+        res.locals.user = {
+          username: 'tom',
+        }
+      })
+      it('will render add prison address page', async () => {
+        await controller.addWelshPrisonAddress(req, res)
+
+        expect(res.render).toHaveBeenCalledWith('pages/prison-register/addWelshPrisonAddress', {
+          form: expect.objectContaining({}),
+          errors: [],
+        })
+      })
+      it('will pass through form to page', async () => {
+        await controller.addWelshPrisonAddress(req, res)
+
+        expect(res.render).toHaveBeenCalledWith('pages/prison-register/addWelshPrisonAddress', {
+          form: {
+            addressline1inwelsh: 'line 1',
+            addressline2inwelsh: 'line 2',
+            countyinwelsh: 'Galmorgan',
+            towninwelsh: 'Carchar Caerdydd',
+          },
+          errors: [],
+        })
+      })
+    })
+
     describe('submitAddPrisonAddress', () => {
       beforeEach(() => {
         req.session.addPrisonAddressForm = {
@@ -788,6 +892,47 @@ describe('Prison Register controller', () => {
         await controller.submitAddPrisonAddress(req, res)
 
         expect(res.redirect).toHaveBeenCalledWith('/prison-register/details?id=MDI&action=UPDATED')
+      })
+    })
+
+    describe('submitAddWelshPrisonAddress', () => {
+      beforeEach(() => {
+        req.session.addWelshPrisonAddressForm = {
+          addressline1inwelsh: 'line 1',
+          addressline2inwelsh: 'line 2',
+          countyinwelsh: 'Galmorgan',
+          towninwelsh: 'Carchar Caerdydd',
+        }
+        req.body = {
+          prisonId: 'CFI',
+          addressId: '123',
+          ...req.session.addWelshPrisonAddressForm,
+        }
+
+        res.locals.user = {
+          username: 'tom',
+        }
+      })
+      it('will add welsh prison address', async () => {
+        await controller.submitAddWelshPrisonAddress(req, res)
+
+        expect(prisonRegisterService.updateAddressWithWelshPrisonAddress).toHaveBeenCalledWith(
+          { username: 'tom' },
+          'CFI',
+          '123',
+          {
+            addressLine1InWelsh: 'line 1',
+            addressLine2InWelsh: 'line 2',
+            countryInWelsh: 'Cymru',
+            countyInWelsh: 'Galmorgan',
+            townInWelsh: 'Carchar Caerdydd',
+          },
+        )
+      })
+      it('will render prison details page', async () => {
+        await controller.submitAddWelshPrisonAddress(req, res)
+
+        expect(res.redirect).toHaveBeenCalledWith('/prison-register/details?id=CFI&action=UPDATED')
       })
     })
 

--- a/server/routes/prisonRegister/prisonRegisterController.ts
+++ b/server/routes/prisonRegister/prisonRegisterController.ts
@@ -8,9 +8,11 @@ import AmendPrisonDetailsView from './amendPrisonDetailsView'
 import trimForm from '../../utils/trim'
 import amendPrisonDetailsValidator from './amendPrisonDetailsValidator'
 import prisonAddressValidator from './prisonAddressValidator'
+import welshPrisonAddressValidator from './welshPrisonAddressValidator'
 import AmendPrisonAddressView from './amendPrisonAddressView'
-import { InsertPrison, UpdatePrisonAddress } from '../../@types/prisonRegister'
+import { InsertPrison, UpdatePrisonAddress, WelshPrisonAddress } from '../../@types/prisonRegister'
 import AddPrisonAddressView from './addPrisonAddressView'
+import AddWelshPrisonAddressView from './addWelshPrisonAddressView'
 import AddNewPrisonDetailsView from './addNewPrisonDetailsView'
 import addNewPrisonDetailsValidator from './addNewPrisonDetailsValidator'
 import AddNewPrisonSummaryView from './addNewPrisonSummaryView'
@@ -205,6 +207,53 @@ export default class PrisonRegisterController {
     const view = new AddPrisonAddressView(req.session.addPrisonAddressForm, req.flash('errors'))
 
     res.render('pages/prison-register/addPrisonAddress', view.renderArgs)
+  }
+
+  async addWelshPrisonAddressStart(req: Request, res: Response): Promise<void> {
+    const { prisonId, addressId } = req.query as {
+      prisonId: string
+      addressId: string
+    }
+
+    req.session.addWelshPrisonAddressForm = {
+      prisonId,
+      addressId,
+    }
+
+    const view = new AddWelshPrisonAddressView(req.session.addWelshPrisonAddressForm, req.flash('errors'))
+    res.render('pages/prison-register/addWelshPrisonAddress', view.renderArgs)
+  }
+
+  async addWelshPrisonAddress(req: Request, res: Response): Promise<void> {
+    const view = new AddWelshPrisonAddressView(req.session.addWelshPrisonAddressForm, req.flash('errors'))
+    res.render('pages/prison-register/addWelshPrisonAddress', view.renderArgs)
+  }
+
+  async submitAddWelshPrisonAddress(req: Request, res: Response): Promise<void> {
+    const { addressId, prisonId } = req.body
+    req.session.addWelshPrisonAddressForm = { ...trimForm(req.body) }
+    res.redirect(
+      await welshPrisonAddressValidator(
+        req.session.addWelshPrisonAddressForm,
+        req,
+        '/prison-register/add-welsh-prison-address',
+        form => {
+          const newWelshAddress: WelshPrisonAddress = {
+            addressLine1InWelsh: form.addressline1inwelsh,
+            addressLine2InWelsh: form.addressline2inwelsh,
+            townInWelsh: form.towninwelsh,
+            countyInWelsh: form.countyinwelsh,
+            countryInWelsh: 'Cymru',
+          }
+          return this.prisonRegisterService.updateAddressWithWelshPrisonAddress(
+            context(res),
+            prisonId,
+            addressId as string,
+            newWelshAddress,
+          )
+        },
+      ),
+    )
   }
 
   async addPrisonAddress(req: Request, res: Response): Promise<void> {

--- a/server/routes/prisonRegister/prisonRegisterRouter.test.ts
+++ b/server/routes/prisonRegister/prisonRegisterRouter.test.ts
@@ -21,4 +21,21 @@ describe('GET /', () => {
         expect(res.text).toContain('Prison Register')
       })
   })
+  it("should render 'Add Welsh prison address for' page", () => {
+    return request(app)
+      .get('/prison-register/add-welsh-prison-address-start')
+      .expect('Content-Type', /html/)
+      .expect(res => {
+        expect(res.text).toContain('Add Welsh prison address for')
+      })
+  })
+
+  it("should render 'add-welsh-prison-address' page", () => {
+    return request(app)
+      .get('/prison-register/add-welsh-prison-address')
+      .expect('Content-Type', /html/)
+      .expect(res => {
+        expect(res.text).toContain('Add Welsh prison address for')
+      })
+  })
 })

--- a/server/routes/prisonRegister/prisonRegisterRouter.ts
+++ b/server/routes/prisonRegister/prisonRegisterRouter.ts
@@ -46,6 +46,18 @@ export default function routes(router: Router, services: Services): Router {
   get('/prison-register/add-prison-address', (req, res) => prisonRegisterController.addPrisonAddress(req, res))
   post('/prison-register/add-prison-address', (req, res) => prisonRegisterController.submitAddPrisonAddress(req, res))
 
+  get('/prison-register/add-welsh-prison-address-start', (req, res) =>
+    prisonRegisterController.addWelshPrisonAddressStart(req, res),
+  )
+
+  get('/prison-register/add-welsh-prison-address', (req, res) =>
+    prisonRegisterController.addWelshPrisonAddress(req, res),
+  )
+
+  post('/prison-register/add-welsh-prison-address', (req, res) =>
+    prisonRegisterController.submitAddWelshPrisonAddress(req, res),
+  )
+
   get('/prison-register/amend-prison-address-start', (req, res) =>
     prisonRegisterController.amendPrisonAddressStart(req, res),
   )

--- a/server/routes/prisonRegister/welshPrisonAddressValidator.test.ts
+++ b/server/routes/prisonRegister/welshPrisonAddressValidator.test.ts
@@ -1,0 +1,78 @@
+import type { WelshPrisonAddressForm } from 'prisonForms'
+import { Request } from 'express'
+import validate from './welshPrisonAddressValidator'
+
+describe('welshPrisonAddressValidator', () => {
+  const req = {
+    flash: jest.fn() as (type: string, message: Array<Record<string, string>>) => number,
+  } as unknown as Request
+
+  const errorUrl = '/prison-register/add-welsh-prison-address'
+
+  const validForm: WelshPrisonAddressForm = {
+    addressId: '21',
+    prisonId: 'CFI',
+    addressline1inwelsh: 'line 1 in welsh',
+    addressline2inwelsh: 'line 21 in welsh',
+    towninwelsh: 'Cardiff',
+    countyinwelsh: 'Glamorgan',
+  }
+
+  describe('validate', () => {
+    let updateService: jest.Mocked<(form: WelshPrisonAddressForm) => Promise<void>>
+    beforeEach(() => {
+      updateService = jest.fn().mockResolvedValue(null)
+      jest.resetAllMocks()
+    })
+    it('returns to prison details when valid', async () => {
+      const form = { ...validForm }
+      const nextPage = await validate(form, req, errorUrl, updateService)
+      expect(nextPage).toEqual('/prison-register/details?id=CFI&action=UPDATED')
+      expect(req.flash).toHaveBeenCalledTimes(0)
+    })
+    it('calls update service when valid', async () => {
+      const form = { ...validForm, description: 'Sheffield Prison' }
+      const nextPage = await validate(form, req, errorUrl, updateService)
+      expect(nextPage).toEqual('/prison-register/details?id=CFI&action=UPDATED')
+      expect(updateService).toHaveBeenCalledWith(form)
+    })
+    it('addressline1 must not be greater than 80 characters', async () => {
+      const form = { ...validForm, addressline1inwelsh: 'A'.repeat(81) }
+      const nextPage = await validate(form, req, errorUrl, updateService)
+      expect(nextPage).toEqual('/prison-register/add-welsh-prison-address')
+      expect(req.flash).toBeCalledWith('errors', [
+        { href: '#addressline1inwelsh', text: 'Enter the first line of the address not greater than 80 characters' },
+      ])
+    })
+    it('addressline2 must not be greater than 80 characters', async () => {
+      const form = { ...validForm, addressline2inwelsh: 'A'.repeat(81) }
+      const nextPage = await validate(form, req, errorUrl, updateService)
+      expect(nextPage).toEqual('/prison-register/add-welsh-prison-address')
+      expect(req.flash).toBeCalledWith('errors', [
+        { href: '#addressline2inwelsh', text: 'Enter the second line of the address not greater than 80 characters' },
+      ])
+    })
+    it('town must not be a blank', async () => {
+      const form = { ...validForm, towninwelsh: '  ' }
+      const nextPage = await validate(form, req, errorUrl, updateService)
+      expect(nextPage).toEqual('/prison-register/add-welsh-prison-address')
+      expect(req.flash).toBeCalledWith('errors', [{ href: '#towninwelsh', text: 'Enter the town or city' }])
+    })
+    it('town must not be greater than 80 characters', async () => {
+      const form = { ...validForm, towninwelsh: 'A'.repeat(81) }
+      const nextPage = await validate(form, req, errorUrl, updateService)
+      expect(nextPage).toEqual('/prison-register/add-welsh-prison-address')
+      expect(req.flash).toBeCalledWith('errors', [
+        { href: '#towninwelsh', text: 'Enter the town or city not greater than 80 characters' },
+      ])
+    })
+    it('county must not be greater than 80 characters', async () => {
+      const form = { ...validForm, countyinwelsh: 'A'.repeat(81) }
+      const nextPage = await validate(form, req, errorUrl, updateService)
+      expect(nextPage).toEqual('/prison-register/add-welsh-prison-address')
+      expect(req.flash).toBeCalledWith('errors', [
+        { href: '#countyinwelsh', text: 'Enter the county not greater than 80 characters' },
+      ])
+    })
+  })
+})

--- a/server/routes/prisonRegister/welshPrisonAddressValidator.ts
+++ b/server/routes/prisonRegister/welshPrisonAddressValidator.ts
@@ -1,0 +1,36 @@
+import { Request } from 'express'
+import type { WelshPrisonAddressForm } from 'prisonForms'
+import validateSync from '../../validation/validation'
+
+export default async function validate(
+  form: WelshPrisonAddressForm,
+  req: Request,
+  errorUrl: string,
+  updateService: (welshPrisonAddressForm: WelshPrisonAddressForm) => Promise<void>,
+): Promise<string> {
+  const errors = validateSync(
+    form,
+    {
+      addressline1inwelsh: ['between:0,80'],
+      addressline2inwelsh: 'between:0,80',
+      towninwelsh: ['required', 'between:0,80'],
+      countyinwelsh: ['between:0,80'],
+    },
+    {
+      'required.towninwelsh': 'Enter the town or city',
+      'between.addressline1inwelsh': 'Enter the first line of the address not greater than 80 characters',
+      'between.addressline2inwelsh': 'Enter the second line of the address not greater than 80 characters',
+      'between.towninwelsh': 'Enter the town or city not greater than 80 characters',
+      'between.countyinwelsh': 'Enter the county not greater than 80 characters',
+    },
+  )
+
+  if (errors.length > 0) {
+    req.flash('errors', errors)
+    return errorUrl
+  }
+
+  await updateService(form)
+
+  return `/prison-register/details?id=${form.prisonId}&action=UPDATED`
+}

--- a/server/routes/testutils/appSetup.ts
+++ b/server/routes/testutils/appSetup.ts
@@ -18,6 +18,7 @@ function appSetup(route: Router, production: boolean): Express {
 
   app.use((req, res, next) => {
     res.locals = {}
+    req.flash = jest.fn()
     res.locals.user = req.user
     next()
   })

--- a/server/routes/testutils/mockPrisonData.ts
+++ b/server/routes/testutils/mockPrisonData.ts
@@ -1,4 +1,4 @@
-import { Prison, PrisonAddress } from '../../@types/prisonRegister'
+import { Prison, PrisonAddress, WelshPrisonAddress } from '../../@types/prisonRegister'
 
 export default {
   prisonAddress: ({
@@ -9,6 +9,11 @@ export default {
     postcode = 'DN7 6BW',
     county = 'South Yorkshire',
     country = 'England',
+    addressLine1InWelsh = undefined,
+    addressLine2InWelsh = undefined,
+    townInWelsh = undefined,
+    countyInWelsh = undefined,
+    countryInWelsh = undefined,
   }: Partial<PrisonAddress>): PrisonAddress =>
     ({
       id,
@@ -18,7 +23,56 @@ export default {
       postcode,
       county,
       country,
+      addressLine1InWelsh,
+      addressLine2InWelsh,
+      townInWelsh,
+      countyInWelsh,
+      countryInWelsh,
     }) as PrisonAddress,
+
+  combinedEnglishAddWelshAddress: ({
+    id = 21,
+    addressLine1 = '2 Knox Road',
+    addressLine2 = null,
+    town = 'Cardiff',
+    postcode = 'CC24 0UG',
+    county = 'Glamorgan',
+    country = 'Wales',
+    addressLine1InWelsh = 'Heol Knox',
+    addressLine2InWelsh = 'Hollybush',
+    townInWelsh = 'Caerdydd',
+    countyInWelsh = 'Glamorgan',
+    countryInWelsh = undefined,
+  }: Partial<PrisonAddress>): PrisonAddress =>
+    ({
+      id,
+      addressLine1,
+      addressLine2,
+      town,
+      postcode,
+      county,
+      country,
+      addressLine1InWelsh,
+      addressLine2InWelsh,
+      townInWelsh,
+      countyInWelsh,
+      countryInWelsh,
+    }) as PrisonAddress,
+
+  welshPrisonAddress: ({
+    addressLine1InWelsh = 'Heol Knox',
+    addressLine2InWelsh = undefined,
+    townInWelsh = 'Caerdydd',
+    countyInWelsh = 'Glamorgan',
+    countryInWelsh = 'Cymru',
+  }: Partial<WelshPrisonAddress>): WelshPrisonAddress =>
+    ({
+      addressLine1InWelsh,
+      addressLine2InWelsh,
+      townInWelsh,
+      countyInWelsh,
+      countryInWelsh,
+    }) as WelshPrisonAddress,
 
   prison: ({
     prisonId = 'ALI',

--- a/server/services/prisonRegisterService.test.ts
+++ b/server/services/prisonRegisterService.test.ts
@@ -5,7 +5,7 @@ import config from '../config'
 import PrisonRegisterService from './prisonRegisterService'
 import TokenStore from '../data/tokenStore'
 import data from '../routes/testutils/mockPrisonData'
-import { InsertPrison, UpdatePrison, UpdatePrisonAddress } from '../@types/prisonRegister'
+import { InsertPrison, UpdatePrison, UpdatePrisonAddress, WelshPrisonAddress } from '../@types/prisonRegister'
 import { moorlandPrison } from '../../integration_tests/mockApis/prisonRegister'
 
 jest.mock('../data/hmppsAuthClient')
@@ -260,6 +260,38 @@ describe('Prison Register service', () => {
         postcode: 'DN7 6BW',
         country: 'England',
       })
+    })
+  })
+
+  describe('updateAddressWithWelshPrisonAddress', () => {
+    const welshPrisonAddress = data.welshPrisonAddress({})
+    beforeEach(() => {
+      hmppsAuthClient = new HmppsAuthClient({} as TokenStore) as jest.Mocked<HmppsAuthClient>
+      prisonRegisterService = new PrisonRegisterService(hmppsAuthClient)
+      fakePrisonRegister
+        .put('/prison-maintenance/id/CFI/welsh-address/21', welshPrisonAddress)
+        .reply(200, welshPrisonAddress)
+    })
+    it('username will be used by client', async () => {
+      await prisonRegisterService.updateAddressWithWelshPrisonAddress(
+        { username: 'tommy' },
+        'CFI',
+        '21',
+        welshPrisonAddress,
+      )
+
+      expect(hmppsAuthClient.getApiClientToken).toHaveBeenCalledWith('tommy')
+    })
+
+    it('will send update prison address', async () => {
+      await prisonRegisterService.updateAddressWithWelshPrisonAddress(
+        { username: 'tommy' },
+        'CFI',
+        '21',
+        welshPrisonAddress,
+      )
+
+      expect(welshPrisonAddress).toEqual(welshPrisonAddress)
     })
   })
 

--- a/server/services/prisonRegisterService.test.ts
+++ b/server/services/prisonRegisterService.test.ts
@@ -5,7 +5,7 @@ import config from '../config'
 import PrisonRegisterService from './prisonRegisterService'
 import TokenStore from '../data/tokenStore'
 import data from '../routes/testutils/mockPrisonData'
-import { InsertPrison, UpdatePrison, UpdatePrisonAddress, WelshPrisonAddress } from '../@types/prisonRegister'
+import { InsertPrison, UpdatePrison, UpdatePrisonAddress } from '../@types/prisonRegister'
 import { moorlandPrison } from '../../integration_tests/mockApis/prisonRegister'
 
 jest.mock('../data/hmppsAuthClient')

--- a/server/services/prisonRegisterService.ts
+++ b/server/services/prisonRegisterService.ts
@@ -3,7 +3,14 @@ import HmppsAuthClient from '../data/hmppsAuthClient'
 import RestClient from '../data/restClient'
 import config from '../config'
 import logger from '../../logger'
-import { Prison, UpdatePrison, PrisonAddress, UpdatePrisonAddress, InsertPrison } from '../@types/prisonRegister'
+import {
+  Prison,
+  UpdatePrison,
+  PrisonAddress,
+  UpdatePrisonAddress,
+  InsertPrison,
+  WelshPrisonAddress,
+} from '../@types/prisonRegister'
 import { AllPrisonsFilter } from '../routes/prisonRegister/prisonMapper'
 
 export interface Context {
@@ -123,6 +130,20 @@ export default class PrisonRegisterService {
         addressLine2: undefinedWhenAbsent(prisonAddress.addressLine2),
         county: undefinedWhenAbsent(prisonAddress.county),
       },
+    })
+  }
+
+  async updateAddressWithWelshPrisonAddress(
+    context: Context,
+    prisonId: string,
+    addressId: string,
+    welshAddress: WelshPrisonAddress,
+  ): Promise<void> {
+    const token = await this.hmppsAuthClient.getApiClientToken(context.username)
+    logger.info(`Amending Welsh prison ${prisonId} address for ${addressId}`)
+    await PrisonRegisterService.restClient(token).put({
+      path: `/prison-maintenance/id/${prisonId}/welsh-address/${addressId}`,
+      data: welshAddress,
     })
   }
 

--- a/server/views/pages/prison-register/addWelshPrisonAddress.njk
+++ b/server/views/pages/prison-register/addWelshPrisonAddress.njk
@@ -1,0 +1,103 @@
+{% extends "../../partials/layout.njk" %}
+{% from "govuk/components/input/macro.njk" import govukInput %}
+{% from "govuk/components/fieldset/macro.njk" import govukFieldset %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
+{% from "govuk/components/radios/macro.njk" import govukRadios %}
+
+{% set pageTitle = applicationName + " - Add Welsh Prison Address" %}
+
+{% macro addressTitle(line1, line2, town) %}
+    {% if line1 and line1.trim() != '' %} {{ line1 }}
+    {% else %}
+        {% if line2 and line2.trim() != '' %} {{ line2 }}
+        {% else %} {{ town }}
+        {% endif %}
+    {% endif %}
+{% endmacro %}
+
+{% block content %}
+
+    <!--suppress HtmlUnknownTarget -->
+    <main class="app-container govuk-body">
+        {% if errors.length > 0 %}
+            {{ govukErrorSummary({
+                titleText: 'There is a problem',
+                errorList: errors,
+                attributes: { 'data-qa-errors': true }
+            }) }}
+        {% endif %}
+        <div class="govuk-grid-row">
+            <div class="govuk-grid-column-full">
+                <h1 class="govuk-heading-xl">Add Welsh prison address for {{ form.prisonId }}</h1>
+            </div>
+
+            <div class="govuk-grid-column-two-thirds">
+                <form action="/prison-register/add-welsh-prison-address" method="post" novalidate>
+                    <input type="hidden" name="_csrf" value="{{ csrfToken }}" />
+                    <input type="hidden" name="prisonId" value="{{ form.prisonId }}" />
+                    <input type="hidden" name="addressId" value="{{ form.addressId }}" />
+
+                    {% call govukFieldset({
+                        legend: {
+                            text: "What is the address for the prison?",
+                            classes: "govuk-fieldset__legend--l",
+                            isPageHeading: true
+                        }
+                    }) %}
+
+                        {{ govukInput({
+                            label: {
+                                html: 'Address (Cyfeiriad) <span class="govuk-visually-hidden">Street line 1 of 2</span>'
+                            },
+                            id: "addressline1inwelsh",
+                            name: "addressline1inwelsh",
+                            value: form.addressline1inwelsh,
+                            errorMessage: errors | findError('addressline1inwelsh')
+                        }) }}
+
+                        {{ govukInput({
+                            label: {
+                                html: '<span class="govuk-visually-hidden">Street line 2 of 2</span>'
+                            },
+                            id: "addressline2inwelsh",
+                            name: "addressline2inwelsh",
+                            value: form.addressline2inwelsh,
+                            errorMessage: errors | findError('addressline2inwelsh')
+                        }) }}
+
+                        {{ govukInput({
+                            label: {
+                                text: "Town or city (Tref neu ddinas)"
+                            },
+                            classes: "govuk-!-width-two-thirds",
+                            id: "towninwelsh",
+                            name: "towninwelsh",
+                            value: form.towninwelsh,
+                            errorMessage: errors | findError('towninwelsh')
+                        }) }}
+
+                        {{ govukInput({
+                            label: {
+                                text: "County (Sir)"
+                            },
+                            classes: "govuk-!-width-two-thirds",
+                            id: "countyinwelsh",
+                            name: "countyinwelsh",
+                            value: form.countyinwelsh,
+                            errorMessage: errors | findError('countyinwelsh')
+                        }) }}
+
+                        <div class="govuk-button-group">
+                            {{ govukButton({
+                                text: "Save"
+                            }) }}
+                            <a class="govuk-link" href="/prison-register/details?id={{ form.prisonId }}">Cancel</a>
+                        </div>
+                    {% endcall %}
+                </form>
+            </div>
+        </div>
+    </main>
+
+{% endblock %}

--- a/server/views/pages/prison-register/prisonDetails.njk
+++ b/server/views/pages/prison-register/prisonDetails.njk
@@ -70,13 +70,16 @@
   {% endif %}
 {% endmacro %}
 
-{% macro renderAddress(line1, line2, town, county, postcode, country) %}
+{% macro renderAddress(line1, line2, town, county, postcode, country, addressId, showAddWelshAddressLink) %}
   {{ line(line1) }}
   {{ line(line2) }}
   {{ line(town) }}
   {{ line(county) }}
   {{ line(postcode) }}
   {{ line(country) }}
+  {% if(isWelshPrison and showAddWelshAddressLink)%}
+    <a href="/prison-register/add-welsh-prison-address-start?prisonId={{prisonDetails.id}}&addressId={{addressId}}" class="govuk-link" data-qa="add-welsh-address-link-{{addressId}}">Add Welsh address</a>
+  {% endif %}
 {% endmacro %}
 
 {% macro addressTitle(line1, line2, town) %}
@@ -96,6 +99,47 @@
 {% endmacro %}
 {% macro deleteAddressUrl(prison, address) %}
   /prison-register/delete-prison-address-start?prisonId={{ prison.id }}&addressId={{ address.id }}
+{% endmacro %}
+
+{#  welsh hrefs temporarily pointing to add address details page #}
+{% macro amendWelshAddressUrl(prison, address) %}
+  /prison-register/add-welsh-prison-address-start?prisonId={{ prison.id }}&addressId={{ address.id }}
+{% endmacro %}
+{% macro deleteWelshAddressUrl(prison, address) %}
+  /prison-register/add-welsh-prison-address-start?prisonId={{ prison.id }}&addressId={{ address.id }}
+{% endmacro %}
+
+{% macro govukSummaryListEnglishPrisonAddress(address, addressLabel, showAddWelshAddressLink) %}
+    {{ govukSummaryList({
+      attributes: { "data-qa": "address-details-section-"+ address.id},
+      rows: [
+        {
+          key: {
+          text: addressLabel
+        },
+          value: {
+          html: renderAddress( address.line1, address.line2, address.town, address.county, address.postcode, address.country, address.id, showAddWelshAddressLink),
+          classes: "address-details"
+        },
+          actions: {
+          items: [
+            {
+              href: amendAddressUrl(prisonDetails, address),
+              text: "Change",
+              visuallyHiddenText: "address details",
+              attributes: { "data-qa": "amend-address-details-link-"+ address.id}
+            },
+            {
+              href: deleteAddressUrl(prisonDetails, address),
+              text: "Delete",
+              visuallyHiddenText: "address details",
+              attributes: { "data-qa": "delete-address-details-link-"+ address.id}
+            }
+          ]
+        }
+        }
+      ]
+    }) }}
 {% endmacro %}
 
 {% macro confirmationPanel(message, attribute) %}
@@ -181,36 +225,42 @@
         <h2 class="flush-left govuk-heading-m govuk-grid-column-one-half">{{ addressTitle(address.line1, address.line2, address.town) }}</h2>
       </div>
     {% endif %}
-    {{ govukSummaryList({
-      attributes: { "data-qa": "address-details-section-"+ address.id},
-      rows: [
-        {
-          key: {
-          text: "Address"
-        },
-          value: {
-          html: renderAddress( address.line1, address.line2, address.town, address.county, address.postcode, address.country),
-          classes: "address-details"
-        },
-          actions: {
-          items: [
-            {
-              href: amendAddressUrl(prisonDetails, address),
-              text: "Change",
-              visuallyHiddenText: "address details",
-              attributes: { "data-qa": "amend-address-details-link-"+ address.id}
-            },
-            {
-              href: deleteAddressUrl(prisonDetails, address),
-              text: "Delete",
-              visuallyHiddenText: "address details",
-              attributes: { "data-qa": "delete-address-details-link-"+ address.id}
-            }
-          ]
-        }
-        }
-      ]
-    }) }}
+
+    {% if address.hasWelshAddress %}
+      {{ govukSummaryListEnglishPrisonAddress(address, "English address", false) }}
+      {{ govukSummaryList({
+        attributes: { "data-qa": "welsh-address-details-section-"+ address.id},
+        rows: [
+          {
+            key: {
+            text: "Welsh address"
+          },
+            value: {
+            html: renderAddress( address.line1inwelsh, address.line2inwelsh, address.towninwelsh, address.countyinwelsh, address.postcode, address.countryinwelsh, address.id, false),
+            classes: "address-details"
+          },
+            actions: {
+            items: [
+              {
+                href: amendWelshAddressUrl(prisonDetails, address),
+                text: "Change",
+                visuallyHiddenText: "welsh address details",
+                attributes: { "data-qa": "amend-welsh-address-details-link-"+ address.id} 
+              },
+              {
+                href: deleteWelshAddressUrl(prisonDetails, address),
+                text: "Delete",
+                visuallyHiddenText: "address details",
+                attributes: { "data-qa": "delete-welsh-address-details-link-"+ address.id}
+              }
+            ]
+          }
+          }
+        ]
+      }) }}
+    {% else %}
+      {{ govukSummaryListEnglishPrisonAddress(address, "Address", true) }}
+    {% endif %}
   {% endfor %}
 
   <div class="govuk-button-group">


### PR DESCRIPTION
[MAP-2041](https://dsdmoj.atlassian.net/jira/software/c/projects/MAP/boards/1354?selectedIssue=MAP-2041)

New feature enabling user to provide a Welsh translation address for a prison if the prison is in Wales. 
Access to add the Welsh prison address is via a link under the English address. The link will only show if the prison is in Wales. 


[MAP-2041]: https://dsdmoj.atlassian.net/browse/MAP-2041?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ